### PR TITLE
Include decorators in `Class` and `FunctionDef` range

### DIFF
--- a/parser/src/python.lalrpop
+++ b/parser/src/python.lalrpop
@@ -964,7 +964,7 @@ WithItem<Goal>: ast::Withitem = {
 };
 
 FuncDef: ast::Stmt = {
-    <decorator_list:Decorator*> <location:@L> <is_async:"async"?> "def" <name:Identifier> <args:Parameters> <r:("->" <Test<"all">>)?> ":" <body:Suite> => {
+    <location:@L> <decorator_list:Decorator*> <is_async:"async"?> "def" <name:Identifier> <args:Parameters> <r:("->" <Test<"all">>)?> ":" <body:Suite> => {
         let args = Box::new(args);
         let returns = r.map(|x| Box::new(x));
         let end_location = body.last().unwrap().end();
@@ -1135,7 +1135,7 @@ KwargParameter<ArgType>: Option<Box<ast::Arg>> = {
 };
 
 ClassDef: ast::Stmt = {
-    <decorator_list:Decorator*> <location:@L> "class" <name:Identifier> <a:("(" ArgumentList ")")?> ":" <body:Suite> => {
+    <location:@L> <decorator_list:Decorator*> "class" <name:Identifier> <a:("(" ArgumentList ")")?> ":" <body:Suite> => {
         let (bases, keywords) = match a {
             Some((_, arg, _)) => (arg.args, arg.keywords),
             None => (vec![], vec![]),

--- a/parser/src/python.rs
+++ b/parser/src/python.rs
@@ -1,5 +1,5 @@
 // auto-generated: "lalrpop 0.20.0"
-// sha3: a33e9abb4be2a3730161519ce0f298452edbc50335b9e0c812d5a1730f1d8816
+// sha3: f95a98ddc92e7f056dba3f921c7c9b36d7725b180106324fd00b6157a1c36fe7
 use crate::{
     ast::{self as ast, Ranged},
     lexer::{LexicalError, LexicalErrorType},
@@ -30961,8 +30961,8 @@ fn __action156<
 #[allow(clippy::too_many_arguments)]
 fn __action157<
 >(
-    (_, decorator_list, _): (TextSize, alloc::vec::Vec<ast::Expr>, TextSize),
     (_, location, _): (TextSize, TextSize, TextSize),
+    (_, decorator_list, _): (TextSize, alloc::vec::Vec<ast::Expr>, TextSize),
     (_, is_async, _): (TextSize, core::option::Option<token::Tok>, TextSize),
     (_, _, _): (TextSize, token::Tok, TextSize),
     (_, name, _): (TextSize, ast::Identifier, TextSize),
@@ -31055,8 +31055,8 @@ fn __action161<
 #[allow(clippy::too_many_arguments)]
 fn __action162<
 >(
-    (_, decorator_list, _): (TextSize, alloc::vec::Vec<ast::Expr>, TextSize),
     (_, location, _): (TextSize, TextSize, TextSize),
+    (_, decorator_list, _): (TextSize, alloc::vec::Vec<ast::Expr>, TextSize),
     (_, _, _): (TextSize, token::Tok, TextSize),
     (_, name, _): (TextSize, ast::Identifier, TextSize),
     (_, a, _): (TextSize, core::option::Option<(token::Tok, ArgumentList, token::Tok)>, TextSize),
@@ -37788,8 +37788,8 @@ fn __action636<
 #[allow(clippy::too_many_arguments)]
 fn __action637<
 >(
-    __0: (TextSize, alloc::vec::Vec<ast::Expr>, TextSize),
-    __1: (TextSize, TextSize, TextSize),
+    __0: (TextSize, TextSize, TextSize),
+    __1: (TextSize, alloc::vec::Vec<ast::Expr>, TextSize),
     __2: (TextSize, token::Tok, TextSize),
     __3: (TextSize, token::Tok, TextSize),
     __4: (TextSize, ast::Identifier, TextSize),
@@ -37821,8 +37821,8 @@ fn __action637<
 #[allow(clippy::too_many_arguments)]
 fn __action638<
 >(
-    __0: (TextSize, alloc::vec::Vec<ast::Expr>, TextSize),
-    __1: (TextSize, TextSize, TextSize),
+    __0: (TextSize, TextSize, TextSize),
+    __1: (TextSize, alloc::vec::Vec<ast::Expr>, TextSize),
     __2: (TextSize, token::Tok, TextSize),
     __3: (TextSize, ast::Identifier, TextSize),
     __4: (TextSize, ast::Arguments, TextSize),
@@ -37991,8 +37991,8 @@ fn __action643<
 #[allow(clippy::too_many_arguments)]
 fn __action644<
 >(
-    __0: (TextSize, alloc::vec::Vec<ast::Expr>, TextSize),
-    __1: (TextSize, TextSize, TextSize),
+    __0: (TextSize, TextSize, TextSize),
+    __1: (TextSize, alloc::vec::Vec<ast::Expr>, TextSize),
     __2: (TextSize, token::Tok, TextSize),
     __3: (TextSize, ast::Identifier, TextSize),
     __4: (TextSize, token::Tok, TextSize),
@@ -38024,8 +38024,8 @@ fn __action644<
 #[allow(clippy::too_many_arguments)]
 fn __action645<
 >(
-    __0: (TextSize, alloc::vec::Vec<ast::Expr>, TextSize),
-    __1: (TextSize, TextSize, TextSize),
+    __0: (TextSize, TextSize, TextSize),
+    __1: (TextSize, alloc::vec::Vec<ast::Expr>, TextSize),
     __2: (TextSize, token::Tok, TextSize),
     __3: (TextSize, ast::Identifier, TextSize),
     __4: (TextSize, token::Tok, TextSize),
@@ -40293,16 +40293,16 @@ fn __action738<
     __7: (TextSize, ast::Suite, TextSize),
 ) -> ast::Stmt
 {
-    let __start0 = __0.2;
-    let __end0 = __1.0;
+    let __start0 = __0.0;
+    let __end0 = __0.0;
     let __temp0 = __action371(
         &__start0,
         &__end0,
     );
     let __temp0 = (__start0, __temp0, __end0);
     __action644(
-        __0,
         __temp0,
+        __0,
         __1,
         __2,
         __3,
@@ -40323,16 +40323,16 @@ fn __action739<
     __4: (TextSize, ast::Suite, TextSize),
 ) -> ast::Stmt
 {
-    let __start0 = __0.2;
-    let __end0 = __1.0;
+    let __start0 = __0.0;
+    let __end0 = __0.0;
     let __temp0 = __action371(
         &__start0,
         &__end0,
     );
     let __temp0 = (__start0, __temp0, __end0);
     __action645(
-        __0,
         __temp0,
+        __0,
         __1,
         __2,
         __3,
@@ -41316,16 +41316,16 @@ fn __action777<
     __7: (TextSize, ast::Suite, TextSize),
 ) -> ast::Stmt
 {
-    let __start0 = __0.2;
-    let __end0 = __1.0;
+    let __start0 = __0.0;
+    let __end0 = __0.0;
     let __temp0 = __action371(
         &__start0,
         &__end0,
     );
     let __temp0 = (__start0, __temp0, __end0);
     __action637(
-        __0,
         __temp0,
+        __0,
         __1,
         __2,
         __3,
@@ -41348,16 +41348,16 @@ fn __action778<
     __6: (TextSize, ast::Suite, TextSize),
 ) -> ast::Stmt
 {
-    let __start0 = __0.2;
-    let __end0 = __1.0;
+    let __start0 = __0.0;
+    let __end0 = __0.0;
     let __temp0 = __action371(
         &__start0,
         &__end0,
     );
     let __temp0 = (__start0, __temp0, __end0);
     __action638(
-        __0,
         __temp0,
+        __0,
         __1,
         __2,
         __3,


### PR DESCRIPTION
This PR changes the `ClassDef` and `FunctionDef` definitions to include the range of their decorators. 

## Example

```py
@test
def f(): 
	pass
```

* Before: The functions' range was from line **2**, column 0 to line 3, column 9
* New: The functions' range spans from line **1**, column 0 to line 3, column 9 (includes the `@test` decorator)

## Motivation

This change is because these are the only nodes for where the property `parent.range.includes(child.range)` does not hold. The fact that this property is not respected means it is e.g. impossible to use a binary search over the AST to find a node by its range. 

## Downsides

The main downside that I'm aware of is that diagnostics using `range.start` to compute the line index for functions and classes may now incorrectly point to the line of the function's decorator instead of the function definition. I don't know if this is a problem for RustPython. Ruff already uses custom infrastructure to extract the range of the function name only to limit the diagnostic range (and e.g. avoid highlighting the whole function or class including the body)

## Ruff

https://github.com/charliermarsh/ruff/pull/4467

