### PR TITLE
Include argument parentheses in range

### DIFF
--- a/parser/src/function.rs
+++ b/parser/src/function.rs
@@ -157,7 +157,6 @@ mod tests {
     use super::*;
     use crate::{ast, parser::ParseErrorType, Parse};
 
-    #[cfg(not(feature = "all-nodes-with-ranges"))]
     macro_rules! function_and_lambda {
         ($($name:ident: $code:expr,)*) => {
             $(
@@ -168,6 +167,12 @@ mod tests {
                 }
             )*
         }
+    }
+
+    #[cfg(feature = "all-nodes-with-ranges")]
+    function_and_lambda! {
+        test_function_no_args_with_ranges: "def f(): pass",
+        test_function_pos_args_with_ranges: "def f(a, b, c): pass",
     }
 
     #[cfg(not(feature = "all-nodes-with-ranges"))]

--- a/parser/src/python.lalrpop
+++ b/parser/src/python.lalrpop
@@ -981,7 +981,12 @@ FuncDef: ast::Stmt = {
 
 Parameters: ast::Arguments = {
     <location:@L> "(" <a: (ParameterList<TypedParameter, StarTypedParameter>)?> ")" <end_location:@R> =>? {
-        let args = a.map(validate_arguments).transpose()?.unwrap_or_else(|| ast::Arguments {
+        let range = optional_range(location, end_location);
+
+        let args = a.map(|mut arguments| {
+            arguments.range = range;
+            validate_arguments(arguments)
+        }).transpose()?.unwrap_or_else(|| ast::Arguments {
             posonlyargs: vec![],
             args: vec![],
             vararg: None,
@@ -989,7 +994,7 @@ Parameters: ast::Arguments = {
             kw_defaults: vec![],
             kwarg: None,
             defaults: vec![],
-            range: optional_range(location, end_location)
+            range
         });
 
         Ok(args)

--- a/parser/src/python.rs
+++ b/parser/src/python.rs
@@ -1,5 +1,5 @@
 // auto-generated: "lalrpop 0.20.0"
-// sha3: 296701055ca179a96941a32e449ac86c8d9717215b1dc90c07a7f617741ffa73
+// sha3: d9f1bf2848c06bf5048a11dc3b2d72d6bbe377e857ab1c930fa1d5e9a4150f93
 use crate::{
     ast::{self as ast, Ranged},
     lexer::{LexicalError, LexicalErrorType},
@@ -30997,7 +30997,12 @@ fn __action158<
 ) -> Result<ast::Arguments,__lalrpop_util::ParseError<TextSize,token::Tok,LexicalError>>
 {
     {
-        let args = a.map(validate_arguments).transpose()?.unwrap_or_else(|| ast::Arguments {
+        let range = optional_range(location, end_location);
+
+        let args = a.map(|mut arguments| {
+            arguments.range = range;
+            validate_arguments(arguments)
+        }).transpose()?.unwrap_or_else(|| ast::Arguments {
             posonlyargs: vec![],
             args: vec![],
             vararg: None,
@@ -31005,7 +31010,7 @@ fn __action158<
             kw_defaults: vec![],
             kwarg: None,
             defaults: vec![],
-            range: optional_range(location, end_location)
+            range
         });
 
         Ok(args)

--- a/parser/src/snapshots/rustpython_parser__function__tests__function_no_args_with_ranges.snap
+++ b/parser/src/snapshots/rustpython_parser__function__tests__function_no_args_with_ranges.snap
@@ -1,0 +1,36 @@
+---
+source: parser/src/function.rs
+expression: parse_ast
+---
+Ok(
+    [
+        FunctionDef(
+            StmtFunctionDef {
+                range: 0..13,
+                name: Identifier(
+                    "f",
+                ),
+                args: Arguments {
+                    range: 5..7,
+                    posonlyargs: [],
+                    args: [],
+                    vararg: None,
+                    kwonlyargs: [],
+                    kw_defaults: [],
+                    kwarg: None,
+                    defaults: [],
+                },
+                body: [
+                    Pass(
+                        StmtPass {
+                            range: 9..13,
+                        },
+                    ),
+                ],
+                decorator_list: [],
+                returns: None,
+                type_comment: None,
+            },
+        ),
+    ],
+)

--- a/parser/src/snapshots/rustpython_parser__function__tests__function_pos_args_with_ranges.snap
+++ b/parser/src/snapshots/rustpython_parser__function__tests__function_pos_args_with_ranges.snap
@@ -1,0 +1,61 @@
+---
+source: parser/src/function.rs
+expression: parse_ast
+---
+Ok(
+    [
+        FunctionDef(
+            StmtFunctionDef {
+                range: 0..20,
+                name: Identifier(
+                    "f",
+                ),
+                args: Arguments {
+                    range: 5..14,
+                    posonlyargs: [],
+                    args: [
+                        Arg {
+                            range: 6..7,
+                            arg: Identifier(
+                                "a",
+                            ),
+                            annotation: None,
+                            type_comment: None,
+                        },
+                        Arg {
+                            range: 9..10,
+                            arg: Identifier(
+                                "b",
+                            ),
+                            annotation: None,
+                            type_comment: None,
+                        },
+                        Arg {
+                            range: 12..13,
+                            arg: Identifier(
+                                "c",
+                            ),
+                            annotation: None,
+                            type_comment: None,
+                        },
+                    ],
+                    vararg: None,
+                    kwonlyargs: [],
+                    kw_defaults: [],
+                    kwarg: None,
+                    defaults: [],
+                },
+                body: [
+                    Pass(
+                        StmtPass {
+                            range: 16..20,
+                        },
+                    ),
+                ],
+                decorator_list: [],
+                returns: None,
+                type_comment: None,
+            },
+        ),
+    ],
+)


### PR DESCRIPTION
This PR changes the parser to include the range of the opening and closing parentheses of function arguments in the `arguments` range.