### PR TITLE
`NamedExpr` include full range

### DIFF
--- a/parser/src/parser.rs
+++ b/parser/src/parser.rs
@@ -1037,7 +1037,7 @@ def args_to_tuple(*args: *Ts) -> Tuple[*Ts]: ...
     #[test]
     #[cfg(not(feature = "all-nodes-with-ranges"))]
     fn decorator_ranges() {
-        let parse_ast = parse_program(
+        let parse_ast = ast::Suite::parse(
             r#"
 @my_decorator
 def test():

--- a/parser/src/python.lalrpop
+++ b/parser/src/python.lalrpop
@@ -1196,7 +1196,7 @@ NamedExpressionTest: ast::Expr = {
 }
 
 NamedExpression: ast::Expr = {
-    <location:@L> <id:Identifier> <end_location:@R> ":=" <value:Test<"all">> => {
+    <location:@L> <id:Identifier> ":=" <value:Test<"all">> <end_location:@R> => {
         ast::Expr::NamedExpr(
             ast::ExprNamedExpr {
                 target: Box::new(ast::Expr::Name(

--- a/parser/src/python.rs
+++ b/parser/src/python.rs
@@ -1,5 +1,5 @@
 // auto-generated: "lalrpop 0.20.0"
-// sha3: d9f1bf2848c06bf5048a11dc3b2d72d6bbe377e857ab1c930fa1d5e9a4150f93
+// sha3: e8cc0d11eb29904c135fe2793b7dc33af644f34e9a673fa815b5e498153d3c95
 use crate::{
     ast::{self as ast, Ranged},
     lexer::{LexicalError, LexicalErrorType},
@@ -31155,9 +31155,9 @@ fn __action168<
 >(
     (_, location, _): (TextSize, TextSize, TextSize),
     (_, id, _): (TextSize, ast::Identifier, TextSize),
-    (_, end_location, _): (TextSize, TextSize, TextSize),
     (_, _, _): (TextSize, token::Tok, TextSize),
     (_, value, _): (TextSize, ast::Expr, TextSize),
+    (_, end_location, _): (TextSize, TextSize, TextSize),
 ) -> ast::Expr
 {
     {
@@ -42457,9 +42457,9 @@ fn __action822<
 fn __action823<
 >(
     __0: (TextSize, ast::Identifier, TextSize),
-    __1: (TextSize, TextSize, TextSize),
-    __2: (TextSize, token::Tok, TextSize),
-    __3: (TextSize, ast::Expr, TextSize),
+    __1: (TextSize, token::Tok, TextSize),
+    __2: (TextSize, ast::Expr, TextSize),
+    __3: (TextSize, TextSize, TextSize),
 ) -> ast::Expr
 {
     let __start0 = __0.0;
@@ -53509,8 +53509,8 @@ fn __action1281<
     __2: (TextSize, ast::Expr, TextSize),
 ) -> ast::Expr
 {
-    let __start0 = __0.2;
-    let __end0 = __1.0;
+    let __start0 = __2.2;
+    let __end0 = __2.2;
     let __temp0 = __action370(
         &__start0,
         &__end0,
@@ -53518,9 +53518,9 @@ fn __action1281<
     let __temp0 = (__start0, __temp0, __end0);
     __action823(
         __0,
-        __temp0,
         __1,
         __2,
+        __temp0,
     )
 }
 

--- a/parser/src/snapshots/rustpython_parser__context__tests__assign_named_expr.snap
+++ b/parser/src/snapshots/rustpython_parser__context__tests__assign_named_expr.snap
@@ -11,7 +11,7 @@ expression: parse_ast
                     range: 3..8,
                     target: Name(
                         ExprName {
-                            range: 3..4,
+                            range: 3..8,
                             id: Identifier(
                                 "x",
                             ),

--- a/parser/src/snapshots/rustpython_parser__parser__tests__match_as_identifier.snap
+++ b/parser/src/snapshots/rustpython_parser__parser__tests__match_as_identifier.snap
@@ -670,7 +670,7 @@ expression: parse_ast
                     range: 510..520,
                     target: Name(
                         ExprName {
-                            range: 510..515,
+                            range: 510..520,
                             id: Identifier(
                                 "match",
                             ),

--- a/parser/src/snapshots/rustpython_parser__parser__tests__parse_named_expression_generator_comprehension.snap
+++ b/parser/src/snapshots/rustpython_parser__parser__tests__parse_named_expression_generator_comprehension.snap
@@ -10,7 +10,7 @@ GeneratorExp(
                 range: 1..11,
                 target: Name(
                     ExprName {
-                        range: 1..2,
+                        range: 1..11,
                         id: Identifier(
                             "x",
                         ),

--- a/parser/src/snapshots/rustpython_parser__parser__tests__patma.snap
+++ b/parser/src/snapshots/rustpython_parser__parser__tests__patma.snap
@@ -1996,7 +1996,7 @@ expression: parse_ast
                                 range: 1472..1482,
                                 target: Name(
                                     ExprName {
-                                        range: 1472..1473,
+                                        range: 1472..1482,
                                         id: Identifier(
                                             "x",
                                         ),
@@ -3880,7 +3880,7 @@ expression: parse_ast
                     range: 2789..2795,
                     target: Name(
                         ExprName {
-                            range: 2789..2790,
+                            range: 2789..2795,
                             id: Identifier(
                                 "w",
                             ),

--- a/parser/src/snapshots/rustpython_parser__parser__tests__with_statement.snap
+++ b/parser/src/snapshots/rustpython_parser__parser__tests__with_statement.snap
@@ -1,6 +1,6 @@
 ---
 source: parser/src/parser.rs
-expression: "parse_program(source, \"<test>\").unwrap()"
+expression: "ast::Suite::parse(source, \"<test>\").unwrap()"
 ---
 [
     With(
@@ -798,7 +798,7 @@ expression: "parse_program(source, \"<test>\").unwrap()"
                             range: 362..368,
                             target: Name(
                                 ExprName {
-                                    range: 362..363,
+                                    range: 362..368,
                                     id: Identifier(
                                         "a",
                                     ),
@@ -840,7 +840,7 @@ expression: "parse_program(source, \"<test>\").unwrap()"
                             range: 382..388,
                             target: Name(
                                 ExprName {
-                                    range: 382..383,
+                                    range: 382..388,
                                     id: Identifier(
                                         "a",
                                     ),
@@ -896,7 +896,7 @@ expression: "parse_program(source, \"<test>\").unwrap()"
                                         range: 407..413,
                                         target: Name(
                                             ExprName {
-                                                range: 407..408,
+                                                range: 407..413,
                                                 id: Identifier(
                                                     "a",
                                                 ),
@@ -919,7 +919,7 @@ expression: "parse_program(source, \"<test>\").unwrap()"
                                         range: 415..421,
                                         target: Name(
                                             ExprName {
-                                                range: 415..416,
+                                                range: 415..421,
                                                 id: Identifier(
                                                     "b",
                                                 ),
@@ -969,7 +969,7 @@ expression: "parse_program(source, \"<test>\").unwrap()"
                                         range: 435..441,
                                         target: Name(
                                             ExprName {
-                                                range: 435..436,
+                                                range: 435..441,
                                                 id: Identifier(
                                                     "a",
                                                 ),
@@ -992,7 +992,7 @@ expression: "parse_program(source, \"<test>\").unwrap()"
                                         range: 443..449,
                                         target: Name(
                                             ExprName {
-                                                range: 443..444,
+                                                range: 443..449,
                                                 id: Identifier(
                                                     "b",
                                                 ),


### PR DESCRIPTION
Change `NamedExpr` to include the full range
