### PR TITLE
Add `Decorator` node

### DIFF
--- a/ast-pyo3/src/gen/wrapper_located.rs
+++ b/ast-pyo3/src/gen/wrapper_located.rs
@@ -3993,6 +3993,39 @@ impl TypeIgnoreTypeIgnore {
     }
 }
 
+#[pyclass(module="rustpython_ast.located", name="_decorator", extends=super::Ast, frozen)]
+#[derive(Clone, Debug)]
+pub struct Decorator(pub &'static ast::Decorator<SourceRange>);
+
+impl From<&'static ast::Decorator<SourceRange>> for Decorator {
+    fn from(node: &'static ast::Decorator<SourceRange>) -> Self {
+        Decorator(node)
+    }
+}
+
+impl ToPyObject for Decorator {
+    fn to_object(&self, py: Python) -> PyObject {
+        let initializer = PyClassInitializer::from(Ast).add_subclass(self.clone());
+        Py::new(py, initializer).unwrap().into_py(py)
+    }
+}
+
+impl ToPyWrapper for ast::Decorator<SourceRange> {
+    #[inline]
+    fn to_py_wrapper(&'static self, py: Python) -> PyResult<Py<PyAny>> {
+        Ok(Decorator(self).to_object(py))
+    }
+}
+
+#[pymethods]
+impl Decorator {
+    #[getter]
+    #[inline]
+    fn get_expression(&self, py: Python) -> PyResult<PyObject> {
+        self.0.expression.to_py_wrapper(py)
+    }
+}
+
 impl ToPyWrapper for ast::ExprContext {
     #[inline]
     fn to_py_wrapper(&self, py: Python) -> PyResult<Py<PyAny>> {
@@ -4409,5 +4442,6 @@ pub fn add_to_module(py: Python, m: &PyModule) -> PyResult<()> {
     super::init_type::<PatternMatchOr, ast::PatternMatchOr>(py, m)?;
     super::init_type::<TypeIgnore, ast::TypeIgnore>(py, m)?;
     super::init_type::<TypeIgnoreTypeIgnore, ast::TypeIgnoreTypeIgnore>(py, m)?;
+    super::init_type::<Decorator, ast::Decorator>(py, m)?;
     Ok(())
 }

--- a/ast-pyo3/src/gen/wrapper_ranged.rs
+++ b/ast-pyo3/src/gen/wrapper_ranged.rs
@@ -3993,6 +3993,39 @@ impl TypeIgnoreTypeIgnore {
     }
 }
 
+#[pyclass(module="rustpython_ast.ranged", name="_decorator", extends=super::Ast, frozen)]
+#[derive(Clone, Debug)]
+pub struct Decorator(pub &'static ast::Decorator<TextRange>);
+
+impl From<&'static ast::Decorator<TextRange>> for Decorator {
+    fn from(node: &'static ast::Decorator<TextRange>) -> Self {
+        Decorator(node)
+    }
+}
+
+impl ToPyObject for Decorator {
+    fn to_object(&self, py: Python) -> PyObject {
+        let initializer = PyClassInitializer::from(Ast).add_subclass(self.clone());
+        Py::new(py, initializer).unwrap().into_py(py)
+    }
+}
+
+impl ToPyWrapper for ast::Decorator<TextRange> {
+    #[inline]
+    fn to_py_wrapper(&'static self, py: Python) -> PyResult<Py<PyAny>> {
+        Ok(Decorator(self).to_object(py))
+    }
+}
+
+#[pymethods]
+impl Decorator {
+    #[getter]
+    #[inline]
+    fn get_expression(&self, py: Python) -> PyResult<PyObject> {
+        self.0.expression.to_py_wrapper(py)
+    }
+}
+
 pub fn add_to_module(py: Python, m: &PyModule) -> PyResult<()> {
     super::init_module(py, m)?;
     super::init_type::<Mod, ast::Mod>(py, m)?;
@@ -4113,5 +4146,6 @@ pub fn add_to_module(py: Python, m: &PyModule) -> PyResult<()> {
     super::init_type::<PatternMatchOr, ast::PatternMatchOr>(py, m)?;
     super::init_type::<TypeIgnore, ast::TypeIgnore>(py, m)?;
     super::init_type::<TypeIgnoreTypeIgnore, ast::TypeIgnoreTypeIgnore>(py, m)?;
+    super::init_type::<Decorator, ast::Decorator>(py, m)?;
     Ok(())
 }

--- a/ast/Python.asdl
+++ b/ast/Python.asdl
@@ -1,5 +1,5 @@
 -- ASDL's 4 builtin types are:
--- identifier, int, string, constant
+-- identifier, int, string, constant, decorator
 
 module Python
 {
@@ -9,17 +9,17 @@ module Python
         | FunctionType(expr* argtypes, expr returns)
 
     stmt = FunctionDef(identifier name, arguments args,
-                       stmt* body, expr* decorator_list, expr? returns,
+                       stmt* body, decorator* decorator_list, expr? returns,
                        string? type_comment)
           | AsyncFunctionDef(identifier name, arguments args,
-                             stmt* body, expr* decorator_list, expr? returns,
+                             stmt* body, decorator* decorator_list, expr? returns,
                              string? type_comment)
 
           | ClassDef(identifier name,
              expr* bases,
              keyword* keywords,
              stmt* body,
-             expr* decorator_list)
+             decorator* decorator_list)
           | Return(expr? value)
 
           | Delete(expr* targets)
@@ -142,4 +142,6 @@ module Python
              attributes (int lineno, int col_offset, int end_lineno, int end_col_offset)
 
     type_ignore = TypeIgnore(int lineno, string tag)
+
+    decorator = (expr expression)
 }

--- a/ast/src/gen/fold.rs
+++ b/ast/src/gen/fold.rs
@@ -507,6 +507,12 @@ pub trait Fold<U> {
     ) -> Result<TypeIgnoreTypeIgnore<Self::TargetU>, Self::Error> {
         fold_type_ignore_type_ignore(self, node)
     }
+    fn fold_decorator(
+        &mut self,
+        node: Decorator<U>,
+    ) -> Result<Decorator<Self::TargetU>, Self::Error> {
+        fold_decorator(self, node)
+    }
 }
 impl<T, U> Foldable<T, U> for Mod<T> {
     type Mapped = Mod<U>;
@@ -2790,4 +2796,23 @@ pub fn fold_type_ignore_type_ignore<U, F: Fold<U> + ?Sized>(
     let tag = Foldable::fold(tag, folder)?;
     let range = folder.map_user_cfg(range, context)?;
     Ok(TypeIgnoreTypeIgnore { lineno, tag, range })
+}
+impl<T, U> Foldable<T, U> for Decorator<T> {
+    type Mapped = Decorator<U>;
+    fn fold<F: Fold<T, TargetU = U> + ?Sized>(
+        self,
+        folder: &mut F,
+    ) -> Result<Self::Mapped, F::Error> {
+        folder.fold_decorator(self)
+    }
+}
+pub fn fold_decorator<U, F: Fold<U> + ?Sized>(
+    #[allow(unused)] folder: &mut F,
+    node: Decorator<U>,
+) -> Result<Decorator<F::TargetU>, F::Error> {
+    let Decorator { expression, range } = node;
+    let context = folder.will_map_user_cfg(&range);
+    let expression = Foldable::fold(expression, folder)?;
+    let range = folder.map_user_cfg(range, context)?;
+    Ok(Decorator { expression, range })
 }

--- a/ast/src/gen/generic.rs
+++ b/ast/src/gen/generic.rs
@@ -23,6 +23,7 @@ pub enum Ast<R = TextRange> {
     MatchCase(MatchCase<R>),
     Pattern(Pattern<R>),
     TypeIgnore(TypeIgnore<R>),
+    Decorator(Decorator<R>),
 }
 impl<R> Node for Ast<R> {
     const NAME: &'static str = "AST";
@@ -137,6 +138,12 @@ impl<R> From<TypeIgnore<R>> for Ast<R> {
     }
 }
 
+impl<R> From<Decorator<R>> for Ast<R> {
+    fn from(node: Decorator<R>) -> Self {
+        Ast::Decorator(node)
+    }
+}
+
 #[derive(Clone, Debug, PartialEq)]
 pub struct ModModule<R = TextRange> {
     pub range: OptionalRange<R>,
@@ -242,7 +249,7 @@ pub struct StmtFunctionDef<R = TextRange> {
     pub name: Identifier,
     pub args: Box<Arguments<R>>,
     pub body: Vec<Stmt<R>>,
-    pub decorator_list: Vec<Expr<R>>,
+    pub decorator_list: Vec<Decorator<R>>,
     pub returns: Option<Box<Expr<R>>>,
     pub type_comment: Option<String>,
 }
@@ -275,7 +282,7 @@ pub struct StmtAsyncFunctionDef<R = TextRange> {
     pub name: Identifier,
     pub args: Box<Arguments<R>>,
     pub body: Vec<Stmt<R>>,
-    pub decorator_list: Vec<Expr<R>>,
+    pub decorator_list: Vec<Decorator<R>>,
     pub returns: Option<Box<Expr<R>>>,
     pub type_comment: Option<String>,
 }
@@ -309,7 +316,7 @@ pub struct StmtClassDef<R = TextRange> {
     pub bases: Vec<Expr<R>>,
     pub keywords: Vec<Keyword<R>>,
     pub body: Vec<Stmt<R>>,
-    pub decorator_list: Vec<Expr<R>>,
+    pub decorator_list: Vec<Decorator<R>>,
 }
 
 impl<R> Node for StmtClassDef<R> {
@@ -2986,4 +2993,15 @@ pub enum TypeIgnore<R = TextRange> {
 impl<R> Node for TypeIgnore<R> {
     const NAME: &'static str = "type_ignore";
     const FIELD_NAMES: &'static [&'static str] = &[];
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct Decorator<R = TextRange> {
+    pub range: OptionalRange<R>,
+    pub expression: Expr<R>,
+}
+
+impl<R> Node for Decorator<R> {
+    const NAME: &'static str = "decorator";
+    const FIELD_NAMES: &'static [&'static str] = &["expression"];
 }

--- a/ast/src/gen/located.rs
+++ b/ast/src/gen/located.rs
@@ -815,3 +815,13 @@ impl Located for TypeIgnore {
         }
     }
 }
+
+pub type Decorator = crate::generic::Decorator<SourceRange>;
+
+#[cfg(feature = "all-nodes-with-ranges")]
+
+impl Located for Decorator {
+    fn range(&self) -> SourceRange {
+        self.range
+    }
+}

--- a/ast/src/gen/ranged.rs
+++ b/ast/src/gen/ranged.rs
@@ -495,3 +495,10 @@ impl Ranged for crate::TypeIgnore {
         }
     }
 }
+
+#[cfg(feature = "all-nodes-with-ranges")]
+impl Ranged for crate::generic::Decorator<TextRange> {
+    fn range(&self) -> TextRange {
+        self.range
+    }
+}

--- a/ast/src/gen/visitor.rs
+++ b/ast/src/gen/visitor.rs
@@ -48,7 +48,7 @@ pub trait Visitor<R = crate::text_size::TextRange> {
             self.visit_stmt(value);
         }
         for value in node.decorator_list {
-            self.visit_expr(value);
+            self.visit_decorator(value);
         }
         if let Some(value) = node.returns {
             self.visit_expr(*value);
@@ -66,7 +66,7 @@ pub trait Visitor<R = crate::text_size::TextRange> {
             self.visit_stmt(value);
         }
         for value in node.decorator_list {
-            self.visit_expr(value);
+            self.visit_decorator(value);
         }
         if let Some(value) = node.returns {
             self.visit_expr(*value);
@@ -86,7 +86,7 @@ pub trait Visitor<R = crate::text_size::TextRange> {
             self.visit_stmt(value);
         }
         for value in node.decorator_list {
-            self.visit_expr(value);
+            self.visit_decorator(value);
         }
     }
     fn visit_stmt_Return(&mut self, node: StmtReturn<R>) {
@@ -810,4 +810,8 @@ pub trait Visitor<R = crate::text_size::TextRange> {
             self.visit_pattern(value);
         }
     }
+    fn visit_decorator(&mut self, node: Decorator<R>) {
+        self.generic_visit_decorator(node)
+    }
+    fn generic_visit_decorator(&mut self, node: Decorator<R>) {}
 }

--- a/parser/src/parser.rs
+++ b/parser/src/parser.rs
@@ -1035,7 +1035,7 @@ def args_to_tuple(*args: *Ts) -> Tuple[*Ts]: ...
     }
 
     #[test]
-    #[cfg(not(feature = "all-nodes-with-ranges"))]
+    #[cfg(feature = "all-nodes-with-ranges")]
     fn decorator_ranges() {
         let parse_ast = parse_program(
             r#"

--- a/parser/src/python.lalrpop
+++ b/parser/src/python.lalrpop
@@ -1162,9 +1162,9 @@ ClassDef: ast::Stmt = {
 };
 
 // Decorators:
-Decorator: ast::Expr = {
-    <location:@L> "@" <p:NamedExpressionTest> "\n" => {
-        p
+Decorator: ast::Decorator = {
+    <location:@L> "@" <p:NamedExpressionTest> <end_location:@R> "\n" => {
+        ast::Decorator { range: optional_range(location, end_location), expression: p }
     },
 };
 

--- a/parser/src/python.rs
+++ b/parser/src/python.rs
@@ -1,5 +1,5 @@
 // auto-generated: "lalrpop 0.20.0"
-// sha3: d9f1bf2848c06bf5048a11dc3b2d72d6bbe377e857ab1c930fa1d5e9a4150f93
+// sha3: b83b5a9db0885d1dd840c413dfeaeb3c0acd9fc2375eb9f521aa35858a874aa1
 use crate::{
     ast::{self as ast, Ranged},
     lexer::{LexicalError, LexicalErrorType},
@@ -96,37 +96,39 @@ mod __parse__Top {
         Variant52(core::option::Option<Vec<ast::Comprehension>>),
         Variant53(ast::Cmpop),
         Variant54(ast::Constant),
-        Variant55((Option<Box<ast::Expr>>, ast::Expr)),
-        Variant56((ast::Expr, ast::Expr)),
-        Variant57(Vec<(Option<Box<ast::Expr>>, ast::Expr)>),
-        Variant58(core::option::Option<Vec<(Option<Box<ast::Expr>>, ast::Expr)>>),
-        Variant59(ast::Excepthandler),
-        Variant60(alloc::vec::Vec<ast::Excepthandler>),
-        Variant61(core::option::Option<(Option<(TextSize, TextSize, Option<ast::Identifier>)>, ast::Expr)>),
-        Variant62(ast::Alias),
-        Variant63(Vec<ast::Alias>),
-        Variant64(ast::Int),
-        Variant65(alloc::vec::Vec<ast::Int>),
-        Variant66((Option<ast::Int>, Option<ast::Identifier>)),
-        Variant67(ast::MatchCase),
-        Variant68(alloc::vec::Vec<ast::MatchCase>),
-        Variant69((ast::Identifier, ast::Pattern)),
-        Variant70((ast::Expr, ast::Pattern)),
-        Variant71(Vec<ast::Identifier>),
-        Variant72(Vec<(ast::Identifier, ast::Pattern)>),
-        Variant73(Vec<(ast::Expr, ast::Pattern)>),
-        Variant74(Vec<(ast::Arg, Option<ast::Expr>)>),
-        Variant75((Vec<(ast::Arg, Option<ast::Expr>)>, Vec<(ast::Arg, Option<ast::Expr>)>)),
-        Variant76(core::option::Option<ast::Pattern>),
-        Variant77(ast::Comprehension),
-        Variant78(alloc::vec::Vec<ast::Comprehension>),
-        Variant79(Option<ast::Expr>),
-        Variant80(core::option::Option<Option<ast::Expr>>),
-        Variant81(ast::Arg),
-        Variant82(core::option::Option<ast::Arg>),
-        Variant83(Vec<ast::Stmt>),
-        Variant84(ast::Mod),
-        Variant85(ast::Unaryop),
+        Variant55(ast::Decorator),
+        Variant56(alloc::vec::Vec<ast::Decorator>),
+        Variant57((Option<Box<ast::Expr>>, ast::Expr)),
+        Variant58((ast::Expr, ast::Expr)),
+        Variant59(Vec<(Option<Box<ast::Expr>>, ast::Expr)>),
+        Variant60(core::option::Option<Vec<(Option<Box<ast::Expr>>, ast::Expr)>>),
+        Variant61(ast::Excepthandler),
+        Variant62(alloc::vec::Vec<ast::Excepthandler>),
+        Variant63(core::option::Option<(Option<(TextSize, TextSize, Option<ast::Identifier>)>, ast::Expr)>),
+        Variant64(ast::Alias),
+        Variant65(Vec<ast::Alias>),
+        Variant66(ast::Int),
+        Variant67(alloc::vec::Vec<ast::Int>),
+        Variant68((Option<ast::Int>, Option<ast::Identifier>)),
+        Variant69(ast::MatchCase),
+        Variant70(alloc::vec::Vec<ast::MatchCase>),
+        Variant71((ast::Identifier, ast::Pattern)),
+        Variant72((ast::Expr, ast::Pattern)),
+        Variant73(Vec<ast::Identifier>),
+        Variant74(Vec<(ast::Identifier, ast::Pattern)>),
+        Variant75(Vec<(ast::Expr, ast::Pattern)>),
+        Variant76(Vec<(ast::Arg, Option<ast::Expr>)>),
+        Variant77((Vec<(ast::Arg, Option<ast::Expr>)>, Vec<(ast::Arg, Option<ast::Expr>)>)),
+        Variant78(core::option::Option<ast::Pattern>),
+        Variant79(ast::Comprehension),
+        Variant80(alloc::vec::Vec<ast::Comprehension>),
+        Variant81(Option<ast::Expr>),
+        Variant82(core::option::Option<Option<ast::Expr>>),
+        Variant83(ast::Arg),
+        Variant84(core::option::Option<ast::Arg>),
+        Variant85(Vec<ast::Stmt>),
+        Variant86(ast::Mod),
+        Variant87(ast::Unaryop),
     }
     const __ACTION: &[i16] = &[
         // State 0
@@ -11042,7 +11044,7 @@ mod __parse__Top {
                 assert!(__symbols.len() >= 5);
                 let __sym4 = __pop_Variant9(__symbols);
                 let __sym3 = __pop_Variant0(__symbols);
-                let __sym2 = __pop_Variant81(__symbols);
+                let __sym2 = __pop_Variant83(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
                 let __sym0 = __pop_Variant0(__symbols);
                 let __start = __sym0.0;
@@ -11076,7 +11078,7 @@ mod __parse__Top {
                 let __sym5 = __pop_Variant9(__symbols);
                 let __sym4 = __pop_Variant0(__symbols);
                 let __sym3 = __pop_Variant12(__symbols);
-                let __sym2 = __pop_Variant81(__symbols);
+                let __sym2 = __pop_Variant83(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
                 let __sym0 = __pop_Variant0(__symbols);
                 let __start = __sym0.0;
@@ -11108,7 +11110,7 @@ mod __parse__Top {
             29 => {
                 // ("," <ParameterListStarArgs<TypedParameter, StarTypedParameter>>) = ",", "*", StarTypedParameter => ActionFn(916);
                 assert!(__symbols.len() >= 3);
-                let __sym2 = __pop_Variant81(__symbols);
+                let __sym2 = __pop_Variant83(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
                 let __sym0 = __pop_Variant0(__symbols);
                 let __start = __sym0.0;
@@ -11138,7 +11140,7 @@ mod __parse__Top {
                 // ("," <ParameterListStarArgs<TypedParameter, StarTypedParameter>>) = ",", "*", StarTypedParameter, ("," <ParameterDef<TypedParameter>>)+ => ActionFn(918);
                 assert!(__symbols.len() >= 4);
                 let __sym3 = __pop_Variant12(__symbols);
-                let __sym2 = __pop_Variant81(__symbols);
+                let __sym2 = __pop_Variant83(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
                 let __sym0 = __pop_Variant0(__symbols);
                 let __start = __sym0.0;
@@ -11170,7 +11172,7 @@ mod __parse__Top {
                 assert!(__symbols.len() >= 5);
                 let __sym4 = __pop_Variant9(__symbols);
                 let __sym3 = __pop_Variant0(__symbols);
-                let __sym2 = __pop_Variant81(__symbols);
+                let __sym2 = __pop_Variant83(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
                 let __sym0 = __pop_Variant0(__symbols);
                 let __start = __sym0.0;
@@ -11204,7 +11206,7 @@ mod __parse__Top {
                 let __sym5 = __pop_Variant9(__symbols);
                 let __sym4 = __pop_Variant0(__symbols);
                 let __sym3 = __pop_Variant12(__symbols);
-                let __sym2 = __pop_Variant81(__symbols);
+                let __sym2 = __pop_Variant83(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
                 let __sym0 = __pop_Variant0(__symbols);
                 let __start = __sym0.0;
@@ -11236,7 +11238,7 @@ mod __parse__Top {
             37 => {
                 // ("," <ParameterListStarArgs<TypedParameter, StarTypedParameter>>)? = ",", "*", StarTypedParameter => ActionFn(940);
                 assert!(__symbols.len() >= 3);
-                let __sym2 = __pop_Variant81(__symbols);
+                let __sym2 = __pop_Variant83(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
                 let __sym0 = __pop_Variant0(__symbols);
                 let __start = __sym0.0;
@@ -11266,7 +11268,7 @@ mod __parse__Top {
                 // ("," <ParameterListStarArgs<TypedParameter, StarTypedParameter>>)? = ",", "*", StarTypedParameter, ("," <ParameterDef<TypedParameter>>)+ => ActionFn(942);
                 assert!(__symbols.len() >= 4);
                 let __sym3 = __pop_Variant12(__symbols);
-                let __sym2 = __pop_Variant81(__symbols);
+                let __sym2 = __pop_Variant83(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
                 let __sym0 = __pop_Variant0(__symbols);
                 let __start = __sym0.0;
@@ -11301,7 +11303,7 @@ mod __parse__Top {
                 assert!(__symbols.len() >= 5);
                 let __sym4 = __pop_Variant9(__symbols);
                 let __sym3 = __pop_Variant0(__symbols);
-                let __sym2 = __pop_Variant81(__symbols);
+                let __sym2 = __pop_Variant83(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
                 let __sym0 = __pop_Variant0(__symbols);
                 let __start = __sym0.0;
@@ -11335,7 +11337,7 @@ mod __parse__Top {
                 let __sym5 = __pop_Variant9(__symbols);
                 let __sym4 = __pop_Variant0(__symbols);
                 let __sym3 = __pop_Variant12(__symbols);
-                let __sym2 = __pop_Variant81(__symbols);
+                let __sym2 = __pop_Variant83(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
                 let __sym0 = __pop_Variant0(__symbols);
                 let __start = __sym0.0;
@@ -11367,7 +11369,7 @@ mod __parse__Top {
             46 => {
                 // ("," <ParameterListStarArgs<UntypedParameter, UntypedParameter>>) = ",", "*", UntypedParameter => ActionFn(976);
                 assert!(__symbols.len() >= 3);
-                let __sym2 = __pop_Variant81(__symbols);
+                let __sym2 = __pop_Variant83(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
                 let __sym0 = __pop_Variant0(__symbols);
                 let __start = __sym0.0;
@@ -11397,7 +11399,7 @@ mod __parse__Top {
                 // ("," <ParameterListStarArgs<UntypedParameter, UntypedParameter>>) = ",", "*", UntypedParameter, ("," <ParameterDef<UntypedParameter>>)+ => ActionFn(978);
                 assert!(__symbols.len() >= 4);
                 let __sym3 = __pop_Variant12(__symbols);
-                let __sym2 = __pop_Variant81(__symbols);
+                let __sym2 = __pop_Variant83(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
                 let __sym0 = __pop_Variant0(__symbols);
                 let __start = __sym0.0;
@@ -11429,7 +11431,7 @@ mod __parse__Top {
                 assert!(__symbols.len() >= 5);
                 let __sym4 = __pop_Variant9(__symbols);
                 let __sym3 = __pop_Variant0(__symbols);
-                let __sym2 = __pop_Variant81(__symbols);
+                let __sym2 = __pop_Variant83(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
                 let __sym0 = __pop_Variant0(__symbols);
                 let __start = __sym0.0;
@@ -11463,7 +11465,7 @@ mod __parse__Top {
                 let __sym5 = __pop_Variant9(__symbols);
                 let __sym4 = __pop_Variant0(__symbols);
                 let __sym3 = __pop_Variant12(__symbols);
-                let __sym2 = __pop_Variant81(__symbols);
+                let __sym2 = __pop_Variant83(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
                 let __sym0 = __pop_Variant0(__symbols);
                 let __start = __sym0.0;
@@ -11495,7 +11497,7 @@ mod __parse__Top {
             54 => {
                 // ("," <ParameterListStarArgs<UntypedParameter, UntypedParameter>>)? = ",", "*", UntypedParameter => ActionFn(1000);
                 assert!(__symbols.len() >= 3);
-                let __sym2 = __pop_Variant81(__symbols);
+                let __sym2 = __pop_Variant83(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
                 let __sym0 = __pop_Variant0(__symbols);
                 let __start = __sym0.0;
@@ -11525,7 +11527,7 @@ mod __parse__Top {
                 // ("," <ParameterListStarArgs<UntypedParameter, UntypedParameter>>)? = ",", "*", UntypedParameter, ("," <ParameterDef<UntypedParameter>>)+ => ActionFn(1002);
                 assert!(__symbols.len() >= 4);
                 let __sym3 = __pop_Variant12(__symbols);
-                let __sym2 = __pop_Variant81(__symbols);
+                let __sym2 = __pop_Variant83(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
                 let __sym0 = __pop_Variant0(__symbols);
                 let __start = __sym0.0;
@@ -11856,11 +11858,11 @@ mod __parse__Top {
                 __reduce158(__lookahead_start, __symbols, core::marker::PhantomData::<()>)
             }
             159 => {
-                // ArgumentList = FunctionArgument => ActionFn(1453);
+                // ArgumentList = FunctionArgument => ActionFn(1454);
                 let __sym0 = __pop_Variant29(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym0.2;
-                let __nt = match super::__action1453::<>(__sym0) {
+                let __nt = match super::__action1454::<>(__sym0) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -11868,10 +11870,10 @@ mod __parse__Top {
                 (1, 83)
             }
             160 => {
-                // ArgumentList =  => ActionFn(1454);
+                // ArgumentList =  => ActionFn(1455);
                 let __start = __lookahead_start.cloned().or_else(|| __symbols.last().map(|s| s.2.clone())).unwrap_or_default();
                 let __end = __start.clone();
-                let __nt = match super::__action1454::<>(&__start, &__end) {
+                let __nt = match super::__action1455::<>(&__start, &__end) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -11879,13 +11881,13 @@ mod __parse__Top {
                 (0, 83)
             }
             161 => {
-                // ArgumentList = (<FunctionArgument> ",")+, FunctionArgument => ActionFn(1455);
+                // ArgumentList = (<FunctionArgument> ",")+, FunctionArgument => ActionFn(1456);
                 assert!(__symbols.len() >= 2);
                 let __sym1 = __pop_Variant29(__symbols);
                 let __sym0 = __pop_Variant30(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym1.2;
-                let __nt = match super::__action1455::<>(__sym0, __sym1) {
+                let __nt = match super::__action1456::<>(__sym0, __sym1) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -11893,11 +11895,11 @@ mod __parse__Top {
                 (2, 83)
             }
             162 => {
-                // ArgumentList = (<FunctionArgument> ",")+ => ActionFn(1456);
+                // ArgumentList = (<FunctionArgument> ",")+ => ActionFn(1457);
                 let __sym0 = __pop_Variant30(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym0.2;
-                let __nt = match super::__action1456::<>(__sym0) {
+                let __nt = match super::__action1457::<>(__sym0) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -12986,7 +12988,7 @@ mod __parse__Top {
                 __reduce429(__lookahead_start, __symbols, core::marker::PhantomData::<()>)
             }
             430 => {
-                // LambdaDef = "lambda", ParameterList<UntypedParameter, UntypedParameter>, ":", Test<"all"> => ActionFn(1621);
+                // LambdaDef = "lambda", ParameterList<UntypedParameter, UntypedParameter>, ":", Test<"all"> => ActionFn(1622);
                 assert!(__symbols.len() >= 4);
                 let __sym3 = __pop_Variant15(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
@@ -12994,7 +12996,7 @@ mod __parse__Top {
                 let __sym0 = __pop_Variant0(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym3.2;
-                let __nt = match super::__action1621::<>(__sym0, __sym1, __sym2, __sym3) {
+                let __nt = match super::__action1622::<>(__sym0, __sym1, __sym2, __sym3) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -13002,14 +13004,14 @@ mod __parse__Top {
                 (4, 160)
             }
             431 => {
-                // LambdaDef = "lambda", ":", Test<"all"> => ActionFn(1622);
+                // LambdaDef = "lambda", ":", Test<"all"> => ActionFn(1623);
                 assert!(__symbols.len() >= 3);
                 let __sym2 = __pop_Variant15(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
                 let __sym0 = __pop_Variant0(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym2.2;
-                let __nt = match super::__action1622::<>(__sym0, __sym1, __sym2) {
+                let __nt = match super::__action1623::<>(__sym0, __sym1, __sym2) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -13044,11 +13046,11 @@ mod __parse__Top {
                 __reduce440(__lookahead_start, __symbols, core::marker::PhantomData::<()>)
             }
             441 => {
-                // LiteralPattern = (@L string @R)+ => ActionFn(1267);
+                // LiteralPattern = (@L string @R)+ => ActionFn(1268);
                 let __sym0 = __pop_Variant41(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym0.2;
-                let __nt = match super::__action1267::<>(__sym0) {
+                let __nt = match super::__action1268::<>(__sym0) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -13329,18 +13331,18 @@ mod __parse__Top {
                 __reduce529(__lookahead_start, __symbols, core::marker::PhantomData::<()>)
             }
             530 => {
-                // ParameterList<TypedParameter, StarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "*", StarTypedParameter, ",", KwargParameter<TypedParameter>, "," => ActionFn(1501);
+                // ParameterList<TypedParameter, StarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "*", StarTypedParameter, ",", KwargParameter<TypedParameter>, "," => ActionFn(1502);
                 assert!(__symbols.len() >= 7);
                 let __sym6 = __pop_Variant0(__symbols);
                 let __sym5 = __pop_Variant9(__symbols);
                 let __sym4 = __pop_Variant0(__symbols);
-                let __sym3 = __pop_Variant81(__symbols);
+                let __sym3 = __pop_Variant83(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant74(__symbols);
+                let __sym0 = __pop_Variant76(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym6.2;
-                let __nt = match super::__action1501::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6) {
+                let __nt = match super::__action1502::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -13348,20 +13350,20 @@ mod __parse__Top {
                 (7, 200)
             }
             531 => {
-                // ParameterList<TypedParameter, StarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "/", ",", "*", StarTypedParameter, ",", KwargParameter<TypedParameter>, "," => ActionFn(1502);
+                // ParameterList<TypedParameter, StarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "/", ",", "*", StarTypedParameter, ",", KwargParameter<TypedParameter>, "," => ActionFn(1503);
                 assert!(__symbols.len() >= 9);
                 let __sym8 = __pop_Variant0(__symbols);
                 let __sym7 = __pop_Variant9(__symbols);
                 let __sym6 = __pop_Variant0(__symbols);
-                let __sym5 = __pop_Variant81(__symbols);
+                let __sym5 = __pop_Variant83(__symbols);
                 let __sym4 = __pop_Variant0(__symbols);
                 let __sym3 = __pop_Variant0(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant74(__symbols);
+                let __sym0 = __pop_Variant76(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym8.2;
-                let __nt = match super::__action1502::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7, __sym8) {
+                let __nt = match super::__action1503::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7, __sym8) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -13369,21 +13371,21 @@ mod __parse__Top {
                 (9, 200)
             }
             532 => {
-                // ParameterList<TypedParameter, StarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "/", ("," <ParameterDef<TypedParameter>>)+, ",", "*", StarTypedParameter, ",", KwargParameter<TypedParameter>, "," => ActionFn(1503);
+                // ParameterList<TypedParameter, StarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "/", ("," <ParameterDef<TypedParameter>>)+, ",", "*", StarTypedParameter, ",", KwargParameter<TypedParameter>, "," => ActionFn(1504);
                 assert!(__symbols.len() >= 10);
                 let __sym9 = __pop_Variant0(__symbols);
                 let __sym8 = __pop_Variant9(__symbols);
                 let __sym7 = __pop_Variant0(__symbols);
-                let __sym6 = __pop_Variant81(__symbols);
+                let __sym6 = __pop_Variant83(__symbols);
                 let __sym5 = __pop_Variant0(__symbols);
                 let __sym4 = __pop_Variant0(__symbols);
                 let __sym3 = __pop_Variant12(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant74(__symbols);
+                let __sym0 = __pop_Variant76(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym9.2;
-                let __nt = match super::__action1503::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7, __sym8, __sym9) {
+                let __nt = match super::__action1504::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7, __sym8, __sym9) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -13391,17 +13393,17 @@ mod __parse__Top {
                 (10, 200)
             }
             533 => {
-                // ParameterList<TypedParameter, StarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "*", ",", KwargParameter<TypedParameter>, "," => ActionFn(1504);
+                // ParameterList<TypedParameter, StarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "*", ",", KwargParameter<TypedParameter>, "," => ActionFn(1505);
                 assert!(__symbols.len() >= 6);
                 let __sym5 = __pop_Variant0(__symbols);
                 let __sym4 = __pop_Variant9(__symbols);
                 let __sym3 = __pop_Variant0(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant74(__symbols);
+                let __sym0 = __pop_Variant76(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym5.2;
-                let __nt = match super::__action1504::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5) {
+                let __nt = match super::__action1505::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -13409,7 +13411,7 @@ mod __parse__Top {
                 (6, 200)
             }
             534 => {
-                // ParameterList<TypedParameter, StarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "/", ",", "*", ",", KwargParameter<TypedParameter>, "," => ActionFn(1505);
+                // ParameterList<TypedParameter, StarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "/", ",", "*", ",", KwargParameter<TypedParameter>, "," => ActionFn(1506);
                 assert!(__symbols.len() >= 8);
                 let __sym7 = __pop_Variant0(__symbols);
                 let __sym6 = __pop_Variant9(__symbols);
@@ -13418,10 +13420,10 @@ mod __parse__Top {
                 let __sym3 = __pop_Variant0(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant74(__symbols);
+                let __sym0 = __pop_Variant76(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym7.2;
-                let __nt = match super::__action1505::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7) {
+                let __nt = match super::__action1506::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -13429,7 +13431,7 @@ mod __parse__Top {
                 (8, 200)
             }
             535 => {
-                // ParameterList<TypedParameter, StarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "/", ("," <ParameterDef<TypedParameter>>)+, ",", "*", ",", KwargParameter<TypedParameter>, "," => ActionFn(1506);
+                // ParameterList<TypedParameter, StarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "/", ("," <ParameterDef<TypedParameter>>)+, ",", "*", ",", KwargParameter<TypedParameter>, "," => ActionFn(1507);
                 assert!(__symbols.len() >= 9);
                 let __sym8 = __pop_Variant0(__symbols);
                 let __sym7 = __pop_Variant9(__symbols);
@@ -13439,10 +13441,10 @@ mod __parse__Top {
                 let __sym3 = __pop_Variant12(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant74(__symbols);
+                let __sym0 = __pop_Variant76(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym8.2;
-                let __nt = match super::__action1506::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7, __sym8) {
+                let __nt = match super::__action1507::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7, __sym8) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -13450,19 +13452,19 @@ mod __parse__Top {
                 (9, 200)
             }
             536 => {
-                // ParameterList<TypedParameter, StarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "*", StarTypedParameter, ("," <ParameterDef<TypedParameter>>)+, ",", KwargParameter<TypedParameter>, "," => ActionFn(1507);
+                // ParameterList<TypedParameter, StarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "*", StarTypedParameter, ("," <ParameterDef<TypedParameter>>)+, ",", KwargParameter<TypedParameter>, "," => ActionFn(1508);
                 assert!(__symbols.len() >= 8);
                 let __sym7 = __pop_Variant0(__symbols);
                 let __sym6 = __pop_Variant9(__symbols);
                 let __sym5 = __pop_Variant0(__symbols);
                 let __sym4 = __pop_Variant12(__symbols);
-                let __sym3 = __pop_Variant81(__symbols);
+                let __sym3 = __pop_Variant83(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant74(__symbols);
+                let __sym0 = __pop_Variant76(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym7.2;
-                let __nt = match super::__action1507::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7) {
+                let __nt = match super::__action1508::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -13470,21 +13472,21 @@ mod __parse__Top {
                 (8, 200)
             }
             537 => {
-                // ParameterList<TypedParameter, StarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "/", ",", "*", StarTypedParameter, ("," <ParameterDef<TypedParameter>>)+, ",", KwargParameter<TypedParameter>, "," => ActionFn(1508);
+                // ParameterList<TypedParameter, StarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "/", ",", "*", StarTypedParameter, ("," <ParameterDef<TypedParameter>>)+, ",", KwargParameter<TypedParameter>, "," => ActionFn(1509);
                 assert!(__symbols.len() >= 10);
                 let __sym9 = __pop_Variant0(__symbols);
                 let __sym8 = __pop_Variant9(__symbols);
                 let __sym7 = __pop_Variant0(__symbols);
                 let __sym6 = __pop_Variant12(__symbols);
-                let __sym5 = __pop_Variant81(__symbols);
+                let __sym5 = __pop_Variant83(__symbols);
                 let __sym4 = __pop_Variant0(__symbols);
                 let __sym3 = __pop_Variant0(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant74(__symbols);
+                let __sym0 = __pop_Variant76(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym9.2;
-                let __nt = match super::__action1508::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7, __sym8, __sym9) {
+                let __nt = match super::__action1509::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7, __sym8, __sym9) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -13492,22 +13494,22 @@ mod __parse__Top {
                 (10, 200)
             }
             538 => {
-                // ParameterList<TypedParameter, StarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "/", ("," <ParameterDef<TypedParameter>>)+, ",", "*", StarTypedParameter, ("," <ParameterDef<TypedParameter>>)+, ",", KwargParameter<TypedParameter>, "," => ActionFn(1509);
+                // ParameterList<TypedParameter, StarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "/", ("," <ParameterDef<TypedParameter>>)+, ",", "*", StarTypedParameter, ("," <ParameterDef<TypedParameter>>)+, ",", KwargParameter<TypedParameter>, "," => ActionFn(1510);
                 assert!(__symbols.len() >= 11);
                 let __sym10 = __pop_Variant0(__symbols);
                 let __sym9 = __pop_Variant9(__symbols);
                 let __sym8 = __pop_Variant0(__symbols);
                 let __sym7 = __pop_Variant12(__symbols);
-                let __sym6 = __pop_Variant81(__symbols);
+                let __sym6 = __pop_Variant83(__symbols);
                 let __sym5 = __pop_Variant0(__symbols);
                 let __sym4 = __pop_Variant0(__symbols);
                 let __sym3 = __pop_Variant12(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant74(__symbols);
+                let __sym0 = __pop_Variant76(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym10.2;
-                let __nt = match super::__action1509::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7, __sym8, __sym9, __sym10) {
+                let __nt = match super::__action1510::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7, __sym8, __sym9, __sym10) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -13515,7 +13517,7 @@ mod __parse__Top {
                 (11, 200)
             }
             539 => {
-                // ParameterList<TypedParameter, StarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "*", ("," <ParameterDef<TypedParameter>>)+, ",", KwargParameter<TypedParameter>, "," => ActionFn(1510);
+                // ParameterList<TypedParameter, StarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "*", ("," <ParameterDef<TypedParameter>>)+, ",", KwargParameter<TypedParameter>, "," => ActionFn(1511);
                 assert!(__symbols.len() >= 7);
                 let __sym6 = __pop_Variant0(__symbols);
                 let __sym5 = __pop_Variant9(__symbols);
@@ -13523,10 +13525,10 @@ mod __parse__Top {
                 let __sym3 = __pop_Variant12(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant74(__symbols);
+                let __sym0 = __pop_Variant76(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym6.2;
-                let __nt = match super::__action1510::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6) {
+                let __nt = match super::__action1511::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -13534,7 +13536,7 @@ mod __parse__Top {
                 (7, 200)
             }
             540 => {
-                // ParameterList<TypedParameter, StarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "/", ",", "*", ("," <ParameterDef<TypedParameter>>)+, ",", KwargParameter<TypedParameter>, "," => ActionFn(1511);
+                // ParameterList<TypedParameter, StarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "/", ",", "*", ("," <ParameterDef<TypedParameter>>)+, ",", KwargParameter<TypedParameter>, "," => ActionFn(1512);
                 assert!(__symbols.len() >= 9);
                 let __sym8 = __pop_Variant0(__symbols);
                 let __sym7 = __pop_Variant9(__symbols);
@@ -13544,10 +13546,10 @@ mod __parse__Top {
                 let __sym3 = __pop_Variant0(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant74(__symbols);
+                let __sym0 = __pop_Variant76(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym8.2;
-                let __nt = match super::__action1511::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7, __sym8) {
+                let __nt = match super::__action1512::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7, __sym8) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -13555,7 +13557,7 @@ mod __parse__Top {
                 (9, 200)
             }
             541 => {
-                // ParameterList<TypedParameter, StarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "/", ("," <ParameterDef<TypedParameter>>)+, ",", "*", ("," <ParameterDef<TypedParameter>>)+, ",", KwargParameter<TypedParameter>, "," => ActionFn(1512);
+                // ParameterList<TypedParameter, StarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "/", ("," <ParameterDef<TypedParameter>>)+, ",", "*", ("," <ParameterDef<TypedParameter>>)+, ",", KwargParameter<TypedParameter>, "," => ActionFn(1513);
                 assert!(__symbols.len() >= 10);
                 let __sym9 = __pop_Variant0(__symbols);
                 let __sym8 = __pop_Variant9(__symbols);
@@ -13566,10 +13568,10 @@ mod __parse__Top {
                 let __sym3 = __pop_Variant12(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant74(__symbols);
+                let __sym0 = __pop_Variant76(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym9.2;
-                let __nt = match super::__action1512::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7, __sym8, __sym9) {
+                let __nt = match super::__action1513::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7, __sym8, __sym9) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -13577,16 +13579,16 @@ mod __parse__Top {
                 (10, 200)
             }
             542 => {
-                // ParameterList<TypedParameter, StarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "*", StarTypedParameter, "," => ActionFn(1513);
+                // ParameterList<TypedParameter, StarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "*", StarTypedParameter, "," => ActionFn(1514);
                 assert!(__symbols.len() >= 5);
                 let __sym4 = __pop_Variant0(__symbols);
-                let __sym3 = __pop_Variant81(__symbols);
+                let __sym3 = __pop_Variant83(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant74(__symbols);
+                let __sym0 = __pop_Variant76(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym4.2;
-                let __nt = match super::__action1513::<>(__sym0, __sym1, __sym2, __sym3, __sym4) {
+                let __nt = match super::__action1514::<>(__sym0, __sym1, __sym2, __sym3, __sym4) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -13594,18 +13596,18 @@ mod __parse__Top {
                 (5, 200)
             }
             543 => {
-                // ParameterList<TypedParameter, StarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "/", ",", "*", StarTypedParameter, "," => ActionFn(1514);
+                // ParameterList<TypedParameter, StarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "/", ",", "*", StarTypedParameter, "," => ActionFn(1515);
                 assert!(__symbols.len() >= 7);
                 let __sym6 = __pop_Variant0(__symbols);
-                let __sym5 = __pop_Variant81(__symbols);
+                let __sym5 = __pop_Variant83(__symbols);
                 let __sym4 = __pop_Variant0(__symbols);
                 let __sym3 = __pop_Variant0(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant74(__symbols);
+                let __sym0 = __pop_Variant76(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym6.2;
-                let __nt = match super::__action1514::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6) {
+                let __nt = match super::__action1515::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -13613,19 +13615,19 @@ mod __parse__Top {
                 (7, 200)
             }
             544 => {
-                // ParameterList<TypedParameter, StarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "/", ("," <ParameterDef<TypedParameter>>)+, ",", "*", StarTypedParameter, "," => ActionFn(1515);
+                // ParameterList<TypedParameter, StarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "/", ("," <ParameterDef<TypedParameter>>)+, ",", "*", StarTypedParameter, "," => ActionFn(1516);
                 assert!(__symbols.len() >= 8);
                 let __sym7 = __pop_Variant0(__symbols);
-                let __sym6 = __pop_Variant81(__symbols);
+                let __sym6 = __pop_Variant83(__symbols);
                 let __sym5 = __pop_Variant0(__symbols);
                 let __sym4 = __pop_Variant0(__symbols);
                 let __sym3 = __pop_Variant12(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant74(__symbols);
+                let __sym0 = __pop_Variant76(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym7.2;
-                let __nt = match super::__action1515::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7) {
+                let __nt = match super::__action1516::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -13633,15 +13635,15 @@ mod __parse__Top {
                 (8, 200)
             }
             545 => {
-                // ParameterList<TypedParameter, StarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "*", "," => ActionFn(1516);
+                // ParameterList<TypedParameter, StarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "*", "," => ActionFn(1517);
                 assert!(__symbols.len() >= 4);
                 let __sym3 = __pop_Variant0(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant74(__symbols);
+                let __sym0 = __pop_Variant76(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym3.2;
-                let __nt = match super::__action1516::<>(__sym0, __sym1, __sym2, __sym3) {
+                let __nt = match super::__action1517::<>(__sym0, __sym1, __sym2, __sym3) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -13649,17 +13651,17 @@ mod __parse__Top {
                 (4, 200)
             }
             546 => {
-                // ParameterList<TypedParameter, StarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "/", ",", "*", "," => ActionFn(1517);
+                // ParameterList<TypedParameter, StarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "/", ",", "*", "," => ActionFn(1518);
                 assert!(__symbols.len() >= 6);
                 let __sym5 = __pop_Variant0(__symbols);
                 let __sym4 = __pop_Variant0(__symbols);
                 let __sym3 = __pop_Variant0(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant74(__symbols);
+                let __sym0 = __pop_Variant76(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym5.2;
-                let __nt = match super::__action1517::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5) {
+                let __nt = match super::__action1518::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -13667,7 +13669,7 @@ mod __parse__Top {
                 (6, 200)
             }
             547 => {
-                // ParameterList<TypedParameter, StarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "/", ("," <ParameterDef<TypedParameter>>)+, ",", "*", "," => ActionFn(1518);
+                // ParameterList<TypedParameter, StarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "/", ("," <ParameterDef<TypedParameter>>)+, ",", "*", "," => ActionFn(1519);
                 assert!(__symbols.len() >= 7);
                 let __sym6 = __pop_Variant0(__symbols);
                 let __sym5 = __pop_Variant0(__symbols);
@@ -13675,10 +13677,10 @@ mod __parse__Top {
                 let __sym3 = __pop_Variant12(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant74(__symbols);
+                let __sym0 = __pop_Variant76(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym6.2;
-                let __nt = match super::__action1518::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6) {
+                let __nt = match super::__action1519::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -13686,17 +13688,17 @@ mod __parse__Top {
                 (7, 200)
             }
             548 => {
-                // ParameterList<TypedParameter, StarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "*", StarTypedParameter, ("," <ParameterDef<TypedParameter>>)+, "," => ActionFn(1519);
+                // ParameterList<TypedParameter, StarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "*", StarTypedParameter, ("," <ParameterDef<TypedParameter>>)+, "," => ActionFn(1520);
                 assert!(__symbols.len() >= 6);
                 let __sym5 = __pop_Variant0(__symbols);
                 let __sym4 = __pop_Variant12(__symbols);
-                let __sym3 = __pop_Variant81(__symbols);
+                let __sym3 = __pop_Variant83(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant74(__symbols);
+                let __sym0 = __pop_Variant76(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym5.2;
-                let __nt = match super::__action1519::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5) {
+                let __nt = match super::__action1520::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -13704,19 +13706,19 @@ mod __parse__Top {
                 (6, 200)
             }
             549 => {
-                // ParameterList<TypedParameter, StarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "/", ",", "*", StarTypedParameter, ("," <ParameterDef<TypedParameter>>)+, "," => ActionFn(1520);
+                // ParameterList<TypedParameter, StarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "/", ",", "*", StarTypedParameter, ("," <ParameterDef<TypedParameter>>)+, "," => ActionFn(1521);
                 assert!(__symbols.len() >= 8);
                 let __sym7 = __pop_Variant0(__symbols);
                 let __sym6 = __pop_Variant12(__symbols);
-                let __sym5 = __pop_Variant81(__symbols);
+                let __sym5 = __pop_Variant83(__symbols);
                 let __sym4 = __pop_Variant0(__symbols);
                 let __sym3 = __pop_Variant0(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant74(__symbols);
+                let __sym0 = __pop_Variant76(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym7.2;
-                let __nt = match super::__action1520::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7) {
+                let __nt = match super::__action1521::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -13724,20 +13726,20 @@ mod __parse__Top {
                 (8, 200)
             }
             550 => {
-                // ParameterList<TypedParameter, StarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "/", ("," <ParameterDef<TypedParameter>>)+, ",", "*", StarTypedParameter, ("," <ParameterDef<TypedParameter>>)+, "," => ActionFn(1521);
+                // ParameterList<TypedParameter, StarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "/", ("," <ParameterDef<TypedParameter>>)+, ",", "*", StarTypedParameter, ("," <ParameterDef<TypedParameter>>)+, "," => ActionFn(1522);
                 assert!(__symbols.len() >= 9);
                 let __sym8 = __pop_Variant0(__symbols);
                 let __sym7 = __pop_Variant12(__symbols);
-                let __sym6 = __pop_Variant81(__symbols);
+                let __sym6 = __pop_Variant83(__symbols);
                 let __sym5 = __pop_Variant0(__symbols);
                 let __sym4 = __pop_Variant0(__symbols);
                 let __sym3 = __pop_Variant12(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant74(__symbols);
+                let __sym0 = __pop_Variant76(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym8.2;
-                let __nt = match super::__action1521::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7, __sym8) {
+                let __nt = match super::__action1522::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7, __sym8) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -13745,16 +13747,16 @@ mod __parse__Top {
                 (9, 200)
             }
             551 => {
-                // ParameterList<TypedParameter, StarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "*", ("," <ParameterDef<TypedParameter>>)+, "," => ActionFn(1522);
+                // ParameterList<TypedParameter, StarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "*", ("," <ParameterDef<TypedParameter>>)+, "," => ActionFn(1523);
                 assert!(__symbols.len() >= 5);
                 let __sym4 = __pop_Variant0(__symbols);
                 let __sym3 = __pop_Variant12(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant74(__symbols);
+                let __sym0 = __pop_Variant76(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym4.2;
-                let __nt = match super::__action1522::<>(__sym0, __sym1, __sym2, __sym3, __sym4) {
+                let __nt = match super::__action1523::<>(__sym0, __sym1, __sym2, __sym3, __sym4) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -13762,7 +13764,7 @@ mod __parse__Top {
                 (5, 200)
             }
             552 => {
-                // ParameterList<TypedParameter, StarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "/", ",", "*", ("," <ParameterDef<TypedParameter>>)+, "," => ActionFn(1523);
+                // ParameterList<TypedParameter, StarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "/", ",", "*", ("," <ParameterDef<TypedParameter>>)+, "," => ActionFn(1524);
                 assert!(__symbols.len() >= 7);
                 let __sym6 = __pop_Variant0(__symbols);
                 let __sym5 = __pop_Variant12(__symbols);
@@ -13770,10 +13772,10 @@ mod __parse__Top {
                 let __sym3 = __pop_Variant0(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant74(__symbols);
+                let __sym0 = __pop_Variant76(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym6.2;
-                let __nt = match super::__action1523::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6) {
+                let __nt = match super::__action1524::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -13781,7 +13783,7 @@ mod __parse__Top {
                 (7, 200)
             }
             553 => {
-                // ParameterList<TypedParameter, StarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "/", ("," <ParameterDef<TypedParameter>>)+, ",", "*", ("," <ParameterDef<TypedParameter>>)+, "," => ActionFn(1524);
+                // ParameterList<TypedParameter, StarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "/", ("," <ParameterDef<TypedParameter>>)+, ",", "*", ("," <ParameterDef<TypedParameter>>)+, "," => ActionFn(1525);
                 assert!(__symbols.len() >= 8);
                 let __sym7 = __pop_Variant0(__symbols);
                 let __sym6 = __pop_Variant12(__symbols);
@@ -13790,10 +13792,10 @@ mod __parse__Top {
                 let __sym3 = __pop_Variant12(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant74(__symbols);
+                let __sym0 = __pop_Variant76(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym7.2;
-                let __nt = match super::__action1524::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7) {
+                let __nt = match super::__action1525::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -13801,13 +13803,13 @@ mod __parse__Top {
                 (8, 200)
             }
             554 => {
-                // ParameterList<TypedParameter, StarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, "," => ActionFn(1525);
+                // ParameterList<TypedParameter, StarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, "," => ActionFn(1526);
                 assert!(__symbols.len() >= 2);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant74(__symbols);
+                let __sym0 = __pop_Variant76(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym1.2;
-                let __nt = match super::__action1525::<>(__sym0, __sym1) {
+                let __nt = match super::__action1526::<>(__sym0, __sym1) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -13815,15 +13817,15 @@ mod __parse__Top {
                 (2, 200)
             }
             555 => {
-                // ParameterList<TypedParameter, StarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "/", "," => ActionFn(1526);
+                // ParameterList<TypedParameter, StarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "/", "," => ActionFn(1527);
                 assert!(__symbols.len() >= 4);
                 let __sym3 = __pop_Variant0(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant74(__symbols);
+                let __sym0 = __pop_Variant76(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym3.2;
-                let __nt = match super::__action1526::<>(__sym0, __sym1, __sym2, __sym3) {
+                let __nt = match super::__action1527::<>(__sym0, __sym1, __sym2, __sym3) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -13831,16 +13833,16 @@ mod __parse__Top {
                 (4, 200)
             }
             556 => {
-                // ParameterList<TypedParameter, StarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "/", ("," <ParameterDef<TypedParameter>>)+, "," => ActionFn(1527);
+                // ParameterList<TypedParameter, StarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "/", ("," <ParameterDef<TypedParameter>>)+, "," => ActionFn(1528);
                 assert!(__symbols.len() >= 5);
                 let __sym4 = __pop_Variant0(__symbols);
                 let __sym3 = __pop_Variant12(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant74(__symbols);
+                let __sym0 = __pop_Variant76(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym4.2;
-                let __nt = match super::__action1527::<>(__sym0, __sym1, __sym2, __sym3, __sym4) {
+                let __nt = match super::__action1528::<>(__sym0, __sym1, __sym2, __sym3, __sym4) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -13848,17 +13850,17 @@ mod __parse__Top {
                 (5, 200)
             }
             557 => {
-                // ParameterList<TypedParameter, StarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "*", StarTypedParameter, ",", KwargParameter<TypedParameter> => ActionFn(1528);
+                // ParameterList<TypedParameter, StarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "*", StarTypedParameter, ",", KwargParameter<TypedParameter> => ActionFn(1529);
                 assert!(__symbols.len() >= 6);
                 let __sym5 = __pop_Variant9(__symbols);
                 let __sym4 = __pop_Variant0(__symbols);
-                let __sym3 = __pop_Variant81(__symbols);
+                let __sym3 = __pop_Variant83(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant74(__symbols);
+                let __sym0 = __pop_Variant76(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym5.2;
-                let __nt = match super::__action1528::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5) {
+                let __nt = match super::__action1529::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -13866,19 +13868,19 @@ mod __parse__Top {
                 (6, 200)
             }
             558 => {
-                // ParameterList<TypedParameter, StarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "/", ",", "*", StarTypedParameter, ",", KwargParameter<TypedParameter> => ActionFn(1529);
+                // ParameterList<TypedParameter, StarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "/", ",", "*", StarTypedParameter, ",", KwargParameter<TypedParameter> => ActionFn(1530);
                 assert!(__symbols.len() >= 8);
                 let __sym7 = __pop_Variant9(__symbols);
                 let __sym6 = __pop_Variant0(__symbols);
-                let __sym5 = __pop_Variant81(__symbols);
+                let __sym5 = __pop_Variant83(__symbols);
                 let __sym4 = __pop_Variant0(__symbols);
                 let __sym3 = __pop_Variant0(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant74(__symbols);
+                let __sym0 = __pop_Variant76(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym7.2;
-                let __nt = match super::__action1529::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7) {
+                let __nt = match super::__action1530::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -13886,20 +13888,20 @@ mod __parse__Top {
                 (8, 200)
             }
             559 => {
-                // ParameterList<TypedParameter, StarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "/", ("," <ParameterDef<TypedParameter>>)+, ",", "*", StarTypedParameter, ",", KwargParameter<TypedParameter> => ActionFn(1530);
+                // ParameterList<TypedParameter, StarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "/", ("," <ParameterDef<TypedParameter>>)+, ",", "*", StarTypedParameter, ",", KwargParameter<TypedParameter> => ActionFn(1531);
                 assert!(__symbols.len() >= 9);
                 let __sym8 = __pop_Variant9(__symbols);
                 let __sym7 = __pop_Variant0(__symbols);
-                let __sym6 = __pop_Variant81(__symbols);
+                let __sym6 = __pop_Variant83(__symbols);
                 let __sym5 = __pop_Variant0(__symbols);
                 let __sym4 = __pop_Variant0(__symbols);
                 let __sym3 = __pop_Variant12(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant74(__symbols);
+                let __sym0 = __pop_Variant76(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym8.2;
-                let __nt = match super::__action1530::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7, __sym8) {
+                let __nt = match super::__action1531::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7, __sym8) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -13907,16 +13909,16 @@ mod __parse__Top {
                 (9, 200)
             }
             560 => {
-                // ParameterList<TypedParameter, StarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "*", ",", KwargParameter<TypedParameter> => ActionFn(1531);
+                // ParameterList<TypedParameter, StarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "*", ",", KwargParameter<TypedParameter> => ActionFn(1532);
                 assert!(__symbols.len() >= 5);
                 let __sym4 = __pop_Variant9(__symbols);
                 let __sym3 = __pop_Variant0(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant74(__symbols);
+                let __sym0 = __pop_Variant76(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym4.2;
-                let __nt = match super::__action1531::<>(__sym0, __sym1, __sym2, __sym3, __sym4) {
+                let __nt = match super::__action1532::<>(__sym0, __sym1, __sym2, __sym3, __sym4) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -13924,7 +13926,7 @@ mod __parse__Top {
                 (5, 200)
             }
             561 => {
-                // ParameterList<TypedParameter, StarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "/", ",", "*", ",", KwargParameter<TypedParameter> => ActionFn(1532);
+                // ParameterList<TypedParameter, StarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "/", ",", "*", ",", KwargParameter<TypedParameter> => ActionFn(1533);
                 assert!(__symbols.len() >= 7);
                 let __sym6 = __pop_Variant9(__symbols);
                 let __sym5 = __pop_Variant0(__symbols);
@@ -13932,10 +13934,10 @@ mod __parse__Top {
                 let __sym3 = __pop_Variant0(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant74(__symbols);
+                let __sym0 = __pop_Variant76(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym6.2;
-                let __nt = match super::__action1532::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6) {
+                let __nt = match super::__action1533::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -13943,7 +13945,7 @@ mod __parse__Top {
                 (7, 200)
             }
             562 => {
-                // ParameterList<TypedParameter, StarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "/", ("," <ParameterDef<TypedParameter>>)+, ",", "*", ",", KwargParameter<TypedParameter> => ActionFn(1533);
+                // ParameterList<TypedParameter, StarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "/", ("," <ParameterDef<TypedParameter>>)+, ",", "*", ",", KwargParameter<TypedParameter> => ActionFn(1534);
                 assert!(__symbols.len() >= 8);
                 let __sym7 = __pop_Variant9(__symbols);
                 let __sym6 = __pop_Variant0(__symbols);
@@ -13952,10 +13954,10 @@ mod __parse__Top {
                 let __sym3 = __pop_Variant12(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant74(__symbols);
+                let __sym0 = __pop_Variant76(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym7.2;
-                let __nt = match super::__action1533::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7) {
+                let __nt = match super::__action1534::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -13963,18 +13965,18 @@ mod __parse__Top {
                 (8, 200)
             }
             563 => {
-                // ParameterList<TypedParameter, StarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "*", StarTypedParameter, ("," <ParameterDef<TypedParameter>>)+, ",", KwargParameter<TypedParameter> => ActionFn(1534);
+                // ParameterList<TypedParameter, StarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "*", StarTypedParameter, ("," <ParameterDef<TypedParameter>>)+, ",", KwargParameter<TypedParameter> => ActionFn(1535);
                 assert!(__symbols.len() >= 7);
                 let __sym6 = __pop_Variant9(__symbols);
                 let __sym5 = __pop_Variant0(__symbols);
                 let __sym4 = __pop_Variant12(__symbols);
-                let __sym3 = __pop_Variant81(__symbols);
+                let __sym3 = __pop_Variant83(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant74(__symbols);
+                let __sym0 = __pop_Variant76(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym6.2;
-                let __nt = match super::__action1534::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6) {
+                let __nt = match super::__action1535::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -13982,20 +13984,20 @@ mod __parse__Top {
                 (7, 200)
             }
             564 => {
-                // ParameterList<TypedParameter, StarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "/", ",", "*", StarTypedParameter, ("," <ParameterDef<TypedParameter>>)+, ",", KwargParameter<TypedParameter> => ActionFn(1535);
+                // ParameterList<TypedParameter, StarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "/", ",", "*", StarTypedParameter, ("," <ParameterDef<TypedParameter>>)+, ",", KwargParameter<TypedParameter> => ActionFn(1536);
                 assert!(__symbols.len() >= 9);
                 let __sym8 = __pop_Variant9(__symbols);
                 let __sym7 = __pop_Variant0(__symbols);
                 let __sym6 = __pop_Variant12(__symbols);
-                let __sym5 = __pop_Variant81(__symbols);
+                let __sym5 = __pop_Variant83(__symbols);
                 let __sym4 = __pop_Variant0(__symbols);
                 let __sym3 = __pop_Variant0(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant74(__symbols);
+                let __sym0 = __pop_Variant76(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym8.2;
-                let __nt = match super::__action1535::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7, __sym8) {
+                let __nt = match super::__action1536::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7, __sym8) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -14003,21 +14005,21 @@ mod __parse__Top {
                 (9, 200)
             }
             565 => {
-                // ParameterList<TypedParameter, StarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "/", ("," <ParameterDef<TypedParameter>>)+, ",", "*", StarTypedParameter, ("," <ParameterDef<TypedParameter>>)+, ",", KwargParameter<TypedParameter> => ActionFn(1536);
+                // ParameterList<TypedParameter, StarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "/", ("," <ParameterDef<TypedParameter>>)+, ",", "*", StarTypedParameter, ("," <ParameterDef<TypedParameter>>)+, ",", KwargParameter<TypedParameter> => ActionFn(1537);
                 assert!(__symbols.len() >= 10);
                 let __sym9 = __pop_Variant9(__symbols);
                 let __sym8 = __pop_Variant0(__symbols);
                 let __sym7 = __pop_Variant12(__symbols);
-                let __sym6 = __pop_Variant81(__symbols);
+                let __sym6 = __pop_Variant83(__symbols);
                 let __sym5 = __pop_Variant0(__symbols);
                 let __sym4 = __pop_Variant0(__symbols);
                 let __sym3 = __pop_Variant12(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant74(__symbols);
+                let __sym0 = __pop_Variant76(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym9.2;
-                let __nt = match super::__action1536::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7, __sym8, __sym9) {
+                let __nt = match super::__action1537::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7, __sym8, __sym9) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -14025,17 +14027,17 @@ mod __parse__Top {
                 (10, 200)
             }
             566 => {
-                // ParameterList<TypedParameter, StarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "*", ("," <ParameterDef<TypedParameter>>)+, ",", KwargParameter<TypedParameter> => ActionFn(1537);
+                // ParameterList<TypedParameter, StarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "*", ("," <ParameterDef<TypedParameter>>)+, ",", KwargParameter<TypedParameter> => ActionFn(1538);
                 assert!(__symbols.len() >= 6);
                 let __sym5 = __pop_Variant9(__symbols);
                 let __sym4 = __pop_Variant0(__symbols);
                 let __sym3 = __pop_Variant12(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant74(__symbols);
+                let __sym0 = __pop_Variant76(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym5.2;
-                let __nt = match super::__action1537::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5) {
+                let __nt = match super::__action1538::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -14043,7 +14045,7 @@ mod __parse__Top {
                 (6, 200)
             }
             567 => {
-                // ParameterList<TypedParameter, StarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "/", ",", "*", ("," <ParameterDef<TypedParameter>>)+, ",", KwargParameter<TypedParameter> => ActionFn(1538);
+                // ParameterList<TypedParameter, StarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "/", ",", "*", ("," <ParameterDef<TypedParameter>>)+, ",", KwargParameter<TypedParameter> => ActionFn(1539);
                 assert!(__symbols.len() >= 8);
                 let __sym7 = __pop_Variant9(__symbols);
                 let __sym6 = __pop_Variant0(__symbols);
@@ -14052,10 +14054,10 @@ mod __parse__Top {
                 let __sym3 = __pop_Variant0(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant74(__symbols);
+                let __sym0 = __pop_Variant76(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym7.2;
-                let __nt = match super::__action1538::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7) {
+                let __nt = match super::__action1539::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -14063,7 +14065,7 @@ mod __parse__Top {
                 (8, 200)
             }
             568 => {
-                // ParameterList<TypedParameter, StarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "/", ("," <ParameterDef<TypedParameter>>)+, ",", "*", ("," <ParameterDef<TypedParameter>>)+, ",", KwargParameter<TypedParameter> => ActionFn(1539);
+                // ParameterList<TypedParameter, StarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "/", ("," <ParameterDef<TypedParameter>>)+, ",", "*", ("," <ParameterDef<TypedParameter>>)+, ",", KwargParameter<TypedParameter> => ActionFn(1540);
                 assert!(__symbols.len() >= 9);
                 let __sym8 = __pop_Variant9(__symbols);
                 let __sym7 = __pop_Variant0(__symbols);
@@ -14073,10 +14075,10 @@ mod __parse__Top {
                 let __sym3 = __pop_Variant12(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant74(__symbols);
+                let __sym0 = __pop_Variant76(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym8.2;
-                let __nt = match super::__action1539::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7, __sym8) {
+                let __nt = match super::__action1540::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7, __sym8) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -14084,15 +14086,15 @@ mod __parse__Top {
                 (9, 200)
             }
             569 => {
-                // ParameterList<TypedParameter, StarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "*", StarTypedParameter => ActionFn(1540);
+                // ParameterList<TypedParameter, StarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "*", StarTypedParameter => ActionFn(1541);
                 assert!(__symbols.len() >= 4);
-                let __sym3 = __pop_Variant81(__symbols);
+                let __sym3 = __pop_Variant83(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant74(__symbols);
+                let __sym0 = __pop_Variant76(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym3.2;
-                let __nt = match super::__action1540::<>(__sym0, __sym1, __sym2, __sym3) {
+                let __nt = match super::__action1541::<>(__sym0, __sym1, __sym2, __sym3) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -14100,17 +14102,17 @@ mod __parse__Top {
                 (4, 200)
             }
             570 => {
-                // ParameterList<TypedParameter, StarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "/", ",", "*", StarTypedParameter => ActionFn(1541);
+                // ParameterList<TypedParameter, StarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "/", ",", "*", StarTypedParameter => ActionFn(1542);
                 assert!(__symbols.len() >= 6);
-                let __sym5 = __pop_Variant81(__symbols);
+                let __sym5 = __pop_Variant83(__symbols);
                 let __sym4 = __pop_Variant0(__symbols);
                 let __sym3 = __pop_Variant0(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant74(__symbols);
+                let __sym0 = __pop_Variant76(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym5.2;
-                let __nt = match super::__action1541::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5) {
+                let __nt = match super::__action1542::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -14118,18 +14120,18 @@ mod __parse__Top {
                 (6, 200)
             }
             571 => {
-                // ParameterList<TypedParameter, StarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "/", ("," <ParameterDef<TypedParameter>>)+, ",", "*", StarTypedParameter => ActionFn(1542);
+                // ParameterList<TypedParameter, StarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "/", ("," <ParameterDef<TypedParameter>>)+, ",", "*", StarTypedParameter => ActionFn(1543);
                 assert!(__symbols.len() >= 7);
-                let __sym6 = __pop_Variant81(__symbols);
+                let __sym6 = __pop_Variant83(__symbols);
                 let __sym5 = __pop_Variant0(__symbols);
                 let __sym4 = __pop_Variant0(__symbols);
                 let __sym3 = __pop_Variant12(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant74(__symbols);
+                let __sym0 = __pop_Variant76(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym6.2;
-                let __nt = match super::__action1542::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6) {
+                let __nt = match super::__action1543::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -14137,14 +14139,14 @@ mod __parse__Top {
                 (7, 200)
             }
             572 => {
-                // ParameterList<TypedParameter, StarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "*" => ActionFn(1543);
+                // ParameterList<TypedParameter, StarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "*" => ActionFn(1544);
                 assert!(__symbols.len() >= 3);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant74(__symbols);
+                let __sym0 = __pop_Variant76(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym2.2;
-                let __nt = match super::__action1543::<>(__sym0, __sym1, __sym2) {
+                let __nt = match super::__action1544::<>(__sym0, __sym1, __sym2) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -14152,16 +14154,16 @@ mod __parse__Top {
                 (3, 200)
             }
             573 => {
-                // ParameterList<TypedParameter, StarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "/", ",", "*" => ActionFn(1544);
+                // ParameterList<TypedParameter, StarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "/", ",", "*" => ActionFn(1545);
                 assert!(__symbols.len() >= 5);
                 let __sym4 = __pop_Variant0(__symbols);
                 let __sym3 = __pop_Variant0(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant74(__symbols);
+                let __sym0 = __pop_Variant76(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym4.2;
-                let __nt = match super::__action1544::<>(__sym0, __sym1, __sym2, __sym3, __sym4) {
+                let __nt = match super::__action1545::<>(__sym0, __sym1, __sym2, __sym3, __sym4) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -14169,17 +14171,17 @@ mod __parse__Top {
                 (5, 200)
             }
             574 => {
-                // ParameterList<TypedParameter, StarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "/", ("," <ParameterDef<TypedParameter>>)+, ",", "*" => ActionFn(1545);
+                // ParameterList<TypedParameter, StarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "/", ("," <ParameterDef<TypedParameter>>)+, ",", "*" => ActionFn(1546);
                 assert!(__symbols.len() >= 6);
                 let __sym5 = __pop_Variant0(__symbols);
                 let __sym4 = __pop_Variant0(__symbols);
                 let __sym3 = __pop_Variant12(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant74(__symbols);
+                let __sym0 = __pop_Variant76(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym5.2;
-                let __nt = match super::__action1545::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5) {
+                let __nt = match super::__action1546::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -14187,16 +14189,16 @@ mod __parse__Top {
                 (6, 200)
             }
             575 => {
-                // ParameterList<TypedParameter, StarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "*", StarTypedParameter, ("," <ParameterDef<TypedParameter>>)+ => ActionFn(1546);
+                // ParameterList<TypedParameter, StarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "*", StarTypedParameter, ("," <ParameterDef<TypedParameter>>)+ => ActionFn(1547);
                 assert!(__symbols.len() >= 5);
                 let __sym4 = __pop_Variant12(__symbols);
-                let __sym3 = __pop_Variant81(__symbols);
+                let __sym3 = __pop_Variant83(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant74(__symbols);
+                let __sym0 = __pop_Variant76(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym4.2;
-                let __nt = match super::__action1546::<>(__sym0, __sym1, __sym2, __sym3, __sym4) {
+                let __nt = match super::__action1547::<>(__sym0, __sym1, __sym2, __sym3, __sym4) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -14204,18 +14206,18 @@ mod __parse__Top {
                 (5, 200)
             }
             576 => {
-                // ParameterList<TypedParameter, StarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "/", ",", "*", StarTypedParameter, ("," <ParameterDef<TypedParameter>>)+ => ActionFn(1547);
+                // ParameterList<TypedParameter, StarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "/", ",", "*", StarTypedParameter, ("," <ParameterDef<TypedParameter>>)+ => ActionFn(1548);
                 assert!(__symbols.len() >= 7);
                 let __sym6 = __pop_Variant12(__symbols);
-                let __sym5 = __pop_Variant81(__symbols);
+                let __sym5 = __pop_Variant83(__symbols);
                 let __sym4 = __pop_Variant0(__symbols);
                 let __sym3 = __pop_Variant0(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant74(__symbols);
+                let __sym0 = __pop_Variant76(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym6.2;
-                let __nt = match super::__action1547::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6) {
+                let __nt = match super::__action1548::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -14223,19 +14225,19 @@ mod __parse__Top {
                 (7, 200)
             }
             577 => {
-                // ParameterList<TypedParameter, StarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "/", ("," <ParameterDef<TypedParameter>>)+, ",", "*", StarTypedParameter, ("," <ParameterDef<TypedParameter>>)+ => ActionFn(1548);
+                // ParameterList<TypedParameter, StarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "/", ("," <ParameterDef<TypedParameter>>)+, ",", "*", StarTypedParameter, ("," <ParameterDef<TypedParameter>>)+ => ActionFn(1549);
                 assert!(__symbols.len() >= 8);
                 let __sym7 = __pop_Variant12(__symbols);
-                let __sym6 = __pop_Variant81(__symbols);
+                let __sym6 = __pop_Variant83(__symbols);
                 let __sym5 = __pop_Variant0(__symbols);
                 let __sym4 = __pop_Variant0(__symbols);
                 let __sym3 = __pop_Variant12(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant74(__symbols);
+                let __sym0 = __pop_Variant76(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym7.2;
-                let __nt = match super::__action1548::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7) {
+                let __nt = match super::__action1549::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -14243,15 +14245,15 @@ mod __parse__Top {
                 (8, 200)
             }
             578 => {
-                // ParameterList<TypedParameter, StarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "*", ("," <ParameterDef<TypedParameter>>)+ => ActionFn(1549);
+                // ParameterList<TypedParameter, StarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "*", ("," <ParameterDef<TypedParameter>>)+ => ActionFn(1550);
                 assert!(__symbols.len() >= 4);
                 let __sym3 = __pop_Variant12(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant74(__symbols);
+                let __sym0 = __pop_Variant76(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym3.2;
-                let __nt = match super::__action1549::<>(__sym0, __sym1, __sym2, __sym3) {
+                let __nt = match super::__action1550::<>(__sym0, __sym1, __sym2, __sym3) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -14259,17 +14261,17 @@ mod __parse__Top {
                 (4, 200)
             }
             579 => {
-                // ParameterList<TypedParameter, StarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "/", ",", "*", ("," <ParameterDef<TypedParameter>>)+ => ActionFn(1550);
+                // ParameterList<TypedParameter, StarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "/", ",", "*", ("," <ParameterDef<TypedParameter>>)+ => ActionFn(1551);
                 assert!(__symbols.len() >= 6);
                 let __sym5 = __pop_Variant12(__symbols);
                 let __sym4 = __pop_Variant0(__symbols);
                 let __sym3 = __pop_Variant0(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant74(__symbols);
+                let __sym0 = __pop_Variant76(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym5.2;
-                let __nt = match super::__action1550::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5) {
+                let __nt = match super::__action1551::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -14277,7 +14279,7 @@ mod __parse__Top {
                 (6, 200)
             }
             580 => {
-                // ParameterList<TypedParameter, StarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "/", ("," <ParameterDef<TypedParameter>>)+, ",", "*", ("," <ParameterDef<TypedParameter>>)+ => ActionFn(1551);
+                // ParameterList<TypedParameter, StarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "/", ("," <ParameterDef<TypedParameter>>)+, ",", "*", ("," <ParameterDef<TypedParameter>>)+ => ActionFn(1552);
                 assert!(__symbols.len() >= 7);
                 let __sym6 = __pop_Variant12(__symbols);
                 let __sym5 = __pop_Variant0(__symbols);
@@ -14285,10 +14287,10 @@ mod __parse__Top {
                 let __sym3 = __pop_Variant12(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant74(__symbols);
+                let __sym0 = __pop_Variant76(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym6.2;
-                let __nt = match super::__action1551::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6) {
+                let __nt = match super::__action1552::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -14296,11 +14298,11 @@ mod __parse__Top {
                 (7, 200)
             }
             581 => {
-                // ParameterList<TypedParameter, StarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>> => ActionFn(1552);
-                let __sym0 = __pop_Variant74(__symbols);
+                // ParameterList<TypedParameter, StarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>> => ActionFn(1553);
+                let __sym0 = __pop_Variant76(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym0.2;
-                let __nt = match super::__action1552::<>(__sym0) {
+                let __nt = match super::__action1553::<>(__sym0) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -14308,14 +14310,14 @@ mod __parse__Top {
                 (1, 200)
             }
             582 => {
-                // ParameterList<TypedParameter, StarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "/" => ActionFn(1553);
+                // ParameterList<TypedParameter, StarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "/" => ActionFn(1554);
                 assert!(__symbols.len() >= 3);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant74(__symbols);
+                let __sym0 = __pop_Variant76(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym2.2;
-                let __nt = match super::__action1553::<>(__sym0, __sym1, __sym2) {
+                let __nt = match super::__action1554::<>(__sym0, __sym1, __sym2) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -14323,28 +14325,12 @@ mod __parse__Top {
                 (3, 200)
             }
             583 => {
-                // ParameterList<TypedParameter, StarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "/", ("," <ParameterDef<TypedParameter>>)+ => ActionFn(1554);
+                // ParameterList<TypedParameter, StarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "/", ("," <ParameterDef<TypedParameter>>)+ => ActionFn(1555);
                 assert!(__symbols.len() >= 4);
                 let __sym3 = __pop_Variant12(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant74(__symbols);
-                let __start = __sym0.0;
-                let __end = __sym3.2;
-                let __nt = match super::__action1554::<>(__sym0, __sym1, __sym2, __sym3) {
-                    Ok(v) => v,
-                    Err(e) => return Some(Err(e)),
-                };
-                __symbols.push((__start, __Symbol::Variant44(__nt), __end));
-                (4, 200)
-            }
-            584 => {
-                // ParameterList<TypedParameter, StarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", KwargParameter<TypedParameter>, "," => ActionFn(1555);
-                assert!(__symbols.len() >= 4);
-                let __sym3 = __pop_Variant0(__symbols);
-                let __sym2 = __pop_Variant9(__symbols);
-                let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant74(__symbols);
+                let __sym0 = __pop_Variant76(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym3.2;
                 let __nt = match super::__action1555::<>(__sym0, __sym1, __sym2, __sym3) {
@@ -14354,18 +14340,34 @@ mod __parse__Top {
                 __symbols.push((__start, __Symbol::Variant44(__nt), __end));
                 (4, 200)
             }
+            584 => {
+                // ParameterList<TypedParameter, StarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", KwargParameter<TypedParameter>, "," => ActionFn(1556);
+                assert!(__symbols.len() >= 4);
+                let __sym3 = __pop_Variant0(__symbols);
+                let __sym2 = __pop_Variant9(__symbols);
+                let __sym1 = __pop_Variant0(__symbols);
+                let __sym0 = __pop_Variant76(__symbols);
+                let __start = __sym0.0;
+                let __end = __sym3.2;
+                let __nt = match super::__action1556::<>(__sym0, __sym1, __sym2, __sym3) {
+                    Ok(v) => v,
+                    Err(e) => return Some(Err(e)),
+                };
+                __symbols.push((__start, __Symbol::Variant44(__nt), __end));
+                (4, 200)
+            }
             585 => {
-                // ParameterList<TypedParameter, StarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "/", ",", KwargParameter<TypedParameter>, "," => ActionFn(1556);
+                // ParameterList<TypedParameter, StarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "/", ",", KwargParameter<TypedParameter>, "," => ActionFn(1557);
                 assert!(__symbols.len() >= 6);
                 let __sym5 = __pop_Variant0(__symbols);
                 let __sym4 = __pop_Variant9(__symbols);
                 let __sym3 = __pop_Variant0(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant74(__symbols);
+                let __sym0 = __pop_Variant76(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym5.2;
-                let __nt = match super::__action1556::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5) {
+                let __nt = match super::__action1557::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -14373,7 +14375,7 @@ mod __parse__Top {
                 (6, 200)
             }
             586 => {
-                // ParameterList<TypedParameter, StarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "/", ("," <ParameterDef<TypedParameter>>)+, ",", KwargParameter<TypedParameter>, "," => ActionFn(1557);
+                // ParameterList<TypedParameter, StarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "/", ("," <ParameterDef<TypedParameter>>)+, ",", KwargParameter<TypedParameter>, "," => ActionFn(1558);
                 assert!(__symbols.len() >= 7);
                 let __sym6 = __pop_Variant0(__symbols);
                 let __sym5 = __pop_Variant9(__symbols);
@@ -14381,10 +14383,10 @@ mod __parse__Top {
                 let __sym3 = __pop_Variant12(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant74(__symbols);
+                let __sym0 = __pop_Variant76(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym6.2;
-                let __nt = match super::__action1557::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6) {
+                let __nt = match super::__action1558::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -14392,14 +14394,14 @@ mod __parse__Top {
                 (7, 200)
             }
             587 => {
-                // ParameterList<TypedParameter, StarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", KwargParameter<TypedParameter> => ActionFn(1558);
+                // ParameterList<TypedParameter, StarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", KwargParameter<TypedParameter> => ActionFn(1559);
                 assert!(__symbols.len() >= 3);
                 let __sym2 = __pop_Variant9(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant74(__symbols);
+                let __sym0 = __pop_Variant76(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym2.2;
-                let __nt = match super::__action1558::<>(__sym0, __sym1, __sym2) {
+                let __nt = match super::__action1559::<>(__sym0, __sym1, __sym2) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -14407,16 +14409,16 @@ mod __parse__Top {
                 (3, 200)
             }
             588 => {
-                // ParameterList<TypedParameter, StarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "/", ",", KwargParameter<TypedParameter> => ActionFn(1559);
+                // ParameterList<TypedParameter, StarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "/", ",", KwargParameter<TypedParameter> => ActionFn(1560);
                 assert!(__symbols.len() >= 5);
                 let __sym4 = __pop_Variant9(__symbols);
                 let __sym3 = __pop_Variant0(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant74(__symbols);
+                let __sym0 = __pop_Variant76(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym4.2;
-                let __nt = match super::__action1559::<>(__sym0, __sym1, __sym2, __sym3, __sym4) {
+                let __nt = match super::__action1560::<>(__sym0, __sym1, __sym2, __sym3, __sym4) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -14424,17 +14426,17 @@ mod __parse__Top {
                 (5, 200)
             }
             589 => {
-                // ParameterList<TypedParameter, StarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "/", ("," <ParameterDef<TypedParameter>>)+, ",", KwargParameter<TypedParameter> => ActionFn(1560);
+                // ParameterList<TypedParameter, StarTypedParameter> = OneOrMore<ParameterDef<TypedParameter>>, ",", "/", ("," <ParameterDef<TypedParameter>>)+, ",", KwargParameter<TypedParameter> => ActionFn(1561);
                 assert!(__symbols.len() >= 6);
                 let __sym5 = __pop_Variant9(__symbols);
                 let __sym4 = __pop_Variant0(__symbols);
                 let __sym3 = __pop_Variant12(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant74(__symbols);
+                let __sym0 = __pop_Variant76(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym5.2;
-                let __nt = match super::__action1560::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5) {
+                let __nt = match super::__action1561::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -14442,16 +14444,16 @@ mod __parse__Top {
                 (6, 200)
             }
             590 => {
-                // ParameterList<TypedParameter, StarTypedParameter> = "*", StarTypedParameter, ",", KwargParameter<TypedParameter>, "," => ActionFn(1308);
+                // ParameterList<TypedParameter, StarTypedParameter> = "*", StarTypedParameter, ",", KwargParameter<TypedParameter>, "," => ActionFn(1309);
                 assert!(__symbols.len() >= 5);
                 let __sym4 = __pop_Variant0(__symbols);
                 let __sym3 = __pop_Variant9(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
-                let __sym1 = __pop_Variant81(__symbols);
+                let __sym1 = __pop_Variant83(__symbols);
                 let __sym0 = __pop_Variant0(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym4.2;
-                let __nt = match super::__action1308::<>(__sym0, __sym1, __sym2, __sym3, __sym4) {
+                let __nt = match super::__action1309::<>(__sym0, __sym1, __sym2, __sym3, __sym4) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -14459,7 +14461,7 @@ mod __parse__Top {
                 (5, 200)
             }
             591 => {
-                // ParameterList<TypedParameter, StarTypedParameter> = "*", ",", KwargParameter<TypedParameter>, "," => ActionFn(1309);
+                // ParameterList<TypedParameter, StarTypedParameter> = "*", ",", KwargParameter<TypedParameter>, "," => ActionFn(1310);
                 assert!(__symbols.len() >= 4);
                 let __sym3 = __pop_Variant0(__symbols);
                 let __sym2 = __pop_Variant9(__symbols);
@@ -14467,7 +14469,7 @@ mod __parse__Top {
                 let __sym0 = __pop_Variant0(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym3.2;
-                let __nt = match super::__action1309::<>(__sym0, __sym1, __sym2, __sym3) {
+                let __nt = match super::__action1310::<>(__sym0, __sym1, __sym2, __sym3) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -14475,17 +14477,17 @@ mod __parse__Top {
                 (4, 200)
             }
             592 => {
-                // ParameterList<TypedParameter, StarTypedParameter> = "*", StarTypedParameter, ("," <ParameterDef<TypedParameter>>)+, ",", KwargParameter<TypedParameter>, "," => ActionFn(1310);
+                // ParameterList<TypedParameter, StarTypedParameter> = "*", StarTypedParameter, ("," <ParameterDef<TypedParameter>>)+, ",", KwargParameter<TypedParameter>, "," => ActionFn(1311);
                 assert!(__symbols.len() >= 6);
                 let __sym5 = __pop_Variant0(__symbols);
                 let __sym4 = __pop_Variant9(__symbols);
                 let __sym3 = __pop_Variant0(__symbols);
                 let __sym2 = __pop_Variant12(__symbols);
-                let __sym1 = __pop_Variant81(__symbols);
+                let __sym1 = __pop_Variant83(__symbols);
                 let __sym0 = __pop_Variant0(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym5.2;
-                let __nt = match super::__action1310::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5) {
+                let __nt = match super::__action1311::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -14493,7 +14495,7 @@ mod __parse__Top {
                 (6, 200)
             }
             593 => {
-                // ParameterList<TypedParameter, StarTypedParameter> = "*", ("," <ParameterDef<TypedParameter>>)+, ",", KwargParameter<TypedParameter>, "," => ActionFn(1311);
+                // ParameterList<TypedParameter, StarTypedParameter> = "*", ("," <ParameterDef<TypedParameter>>)+, ",", KwargParameter<TypedParameter>, "," => ActionFn(1312);
                 assert!(__symbols.len() >= 5);
                 let __sym4 = __pop_Variant0(__symbols);
                 let __sym3 = __pop_Variant9(__symbols);
@@ -14502,7 +14504,7 @@ mod __parse__Top {
                 let __sym0 = __pop_Variant0(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym4.2;
-                let __nt = match super::__action1311::<>(__sym0, __sym1, __sym2, __sym3, __sym4) {
+                let __nt = match super::__action1312::<>(__sym0, __sym1, __sym2, __sym3, __sym4) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -14510,14 +14512,14 @@ mod __parse__Top {
                 (5, 200)
             }
             594 => {
-                // ParameterList<TypedParameter, StarTypedParameter> = "*", StarTypedParameter, "," => ActionFn(1312);
+                // ParameterList<TypedParameter, StarTypedParameter> = "*", StarTypedParameter, "," => ActionFn(1313);
                 assert!(__symbols.len() >= 3);
                 let __sym2 = __pop_Variant0(__symbols);
-                let __sym1 = __pop_Variant81(__symbols);
+                let __sym1 = __pop_Variant83(__symbols);
                 let __sym0 = __pop_Variant0(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym2.2;
-                let __nt = match super::__action1312::<>(__sym0, __sym1, __sym2) {
+                let __nt = match super::__action1313::<>(__sym0, __sym1, __sym2) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -14525,13 +14527,13 @@ mod __parse__Top {
                 (3, 200)
             }
             595 => {
-                // ParameterList<TypedParameter, StarTypedParameter> = "*", "," => ActionFn(1313);
+                // ParameterList<TypedParameter, StarTypedParameter> = "*", "," => ActionFn(1314);
                 assert!(__symbols.len() >= 2);
                 let __sym1 = __pop_Variant0(__symbols);
                 let __sym0 = __pop_Variant0(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym1.2;
-                let __nt = match super::__action1313::<>(__sym0, __sym1) {
+                let __nt = match super::__action1314::<>(__sym0, __sym1) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -14539,15 +14541,15 @@ mod __parse__Top {
                 (2, 200)
             }
             596 => {
-                // ParameterList<TypedParameter, StarTypedParameter> = "*", StarTypedParameter, ("," <ParameterDef<TypedParameter>>)+, "," => ActionFn(1314);
+                // ParameterList<TypedParameter, StarTypedParameter> = "*", StarTypedParameter, ("," <ParameterDef<TypedParameter>>)+, "," => ActionFn(1315);
                 assert!(__symbols.len() >= 4);
                 let __sym3 = __pop_Variant0(__symbols);
                 let __sym2 = __pop_Variant12(__symbols);
-                let __sym1 = __pop_Variant81(__symbols);
+                let __sym1 = __pop_Variant83(__symbols);
                 let __sym0 = __pop_Variant0(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym3.2;
-                let __nt = match super::__action1314::<>(__sym0, __sym1, __sym2, __sym3) {
+                let __nt = match super::__action1315::<>(__sym0, __sym1, __sym2, __sym3) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -14555,14 +14557,14 @@ mod __parse__Top {
                 (4, 200)
             }
             597 => {
-                // ParameterList<TypedParameter, StarTypedParameter> = "*", ("," <ParameterDef<TypedParameter>>)+, "," => ActionFn(1315);
+                // ParameterList<TypedParameter, StarTypedParameter> = "*", ("," <ParameterDef<TypedParameter>>)+, "," => ActionFn(1316);
                 assert!(__symbols.len() >= 3);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant12(__symbols);
                 let __sym0 = __pop_Variant0(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym2.2;
-                let __nt = match super::__action1315::<>(__sym0, __sym1, __sym2) {
+                let __nt = match super::__action1316::<>(__sym0, __sym1, __sym2) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -14570,15 +14572,15 @@ mod __parse__Top {
                 (3, 200)
             }
             598 => {
-                // ParameterList<TypedParameter, StarTypedParameter> = "*", StarTypedParameter, ",", KwargParameter<TypedParameter> => ActionFn(1316);
+                // ParameterList<TypedParameter, StarTypedParameter> = "*", StarTypedParameter, ",", KwargParameter<TypedParameter> => ActionFn(1317);
                 assert!(__symbols.len() >= 4);
                 let __sym3 = __pop_Variant9(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
-                let __sym1 = __pop_Variant81(__symbols);
+                let __sym1 = __pop_Variant83(__symbols);
                 let __sym0 = __pop_Variant0(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym3.2;
-                let __nt = match super::__action1316::<>(__sym0, __sym1, __sym2, __sym3) {
+                let __nt = match super::__action1317::<>(__sym0, __sym1, __sym2, __sym3) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -14586,14 +14588,14 @@ mod __parse__Top {
                 (4, 200)
             }
             599 => {
-                // ParameterList<TypedParameter, StarTypedParameter> = "*", ",", KwargParameter<TypedParameter> => ActionFn(1317);
+                // ParameterList<TypedParameter, StarTypedParameter> = "*", ",", KwargParameter<TypedParameter> => ActionFn(1318);
                 assert!(__symbols.len() >= 3);
                 let __sym2 = __pop_Variant9(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
                 let __sym0 = __pop_Variant0(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym2.2;
-                let __nt = match super::__action1317::<>(__sym0, __sym1, __sym2) {
+                let __nt = match super::__action1318::<>(__sym0, __sym1, __sym2) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -14601,16 +14603,16 @@ mod __parse__Top {
                 (3, 200)
             }
             600 => {
-                // ParameterList<TypedParameter, StarTypedParameter> = "*", StarTypedParameter, ("," <ParameterDef<TypedParameter>>)+, ",", KwargParameter<TypedParameter> => ActionFn(1318);
+                // ParameterList<TypedParameter, StarTypedParameter> = "*", StarTypedParameter, ("," <ParameterDef<TypedParameter>>)+, ",", KwargParameter<TypedParameter> => ActionFn(1319);
                 assert!(__symbols.len() >= 5);
                 let __sym4 = __pop_Variant9(__symbols);
                 let __sym3 = __pop_Variant0(__symbols);
                 let __sym2 = __pop_Variant12(__symbols);
-                let __sym1 = __pop_Variant81(__symbols);
+                let __sym1 = __pop_Variant83(__symbols);
                 let __sym0 = __pop_Variant0(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym4.2;
-                let __nt = match super::__action1318::<>(__sym0, __sym1, __sym2, __sym3, __sym4) {
+                let __nt = match super::__action1319::<>(__sym0, __sym1, __sym2, __sym3, __sym4) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -14618,7 +14620,7 @@ mod __parse__Top {
                 (5, 200)
             }
             601 => {
-                // ParameterList<TypedParameter, StarTypedParameter> = "*", ("," <ParameterDef<TypedParameter>>)+, ",", KwargParameter<TypedParameter> => ActionFn(1319);
+                // ParameterList<TypedParameter, StarTypedParameter> = "*", ("," <ParameterDef<TypedParameter>>)+, ",", KwargParameter<TypedParameter> => ActionFn(1320);
                 assert!(__symbols.len() >= 4);
                 let __sym3 = __pop_Variant9(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
@@ -14626,7 +14628,7 @@ mod __parse__Top {
                 let __sym0 = __pop_Variant0(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym3.2;
-                let __nt = match super::__action1319::<>(__sym0, __sym1, __sym2, __sym3) {
+                let __nt = match super::__action1320::<>(__sym0, __sym1, __sym2, __sym3) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -14634,13 +14636,13 @@ mod __parse__Top {
                 (4, 200)
             }
             602 => {
-                // ParameterList<TypedParameter, StarTypedParameter> = "*", StarTypedParameter => ActionFn(1320);
+                // ParameterList<TypedParameter, StarTypedParameter> = "*", StarTypedParameter => ActionFn(1321);
                 assert!(__symbols.len() >= 2);
-                let __sym1 = __pop_Variant81(__symbols);
+                let __sym1 = __pop_Variant83(__symbols);
                 let __sym0 = __pop_Variant0(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym1.2;
-                let __nt = match super::__action1320::<>(__sym0, __sym1) {
+                let __nt = match super::__action1321::<>(__sym0, __sym1) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -14648,11 +14650,11 @@ mod __parse__Top {
                 (2, 200)
             }
             603 => {
-                // ParameterList<TypedParameter, StarTypedParameter> = "*" => ActionFn(1321);
+                // ParameterList<TypedParameter, StarTypedParameter> = "*" => ActionFn(1322);
                 let __sym0 = __pop_Variant0(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym0.2;
-                let __nt = match super::__action1321::<>(__sym0) {
+                let __nt = match super::__action1322::<>(__sym0) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -14660,14 +14662,14 @@ mod __parse__Top {
                 (1, 200)
             }
             604 => {
-                // ParameterList<TypedParameter, StarTypedParameter> = "*", StarTypedParameter, ("," <ParameterDef<TypedParameter>>)+ => ActionFn(1322);
+                // ParameterList<TypedParameter, StarTypedParameter> = "*", StarTypedParameter, ("," <ParameterDef<TypedParameter>>)+ => ActionFn(1323);
                 assert!(__symbols.len() >= 3);
                 let __sym2 = __pop_Variant12(__symbols);
-                let __sym1 = __pop_Variant81(__symbols);
+                let __sym1 = __pop_Variant83(__symbols);
                 let __sym0 = __pop_Variant0(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym2.2;
-                let __nt = match super::__action1322::<>(__sym0, __sym1, __sym2) {
+                let __nt = match super::__action1323::<>(__sym0, __sym1, __sym2) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -14675,13 +14677,13 @@ mod __parse__Top {
                 (3, 200)
             }
             605 => {
-                // ParameterList<TypedParameter, StarTypedParameter> = "*", ("," <ParameterDef<TypedParameter>>)+ => ActionFn(1323);
+                // ParameterList<TypedParameter, StarTypedParameter> = "*", ("," <ParameterDef<TypedParameter>>)+ => ActionFn(1324);
                 assert!(__symbols.len() >= 2);
                 let __sym1 = __pop_Variant12(__symbols);
                 let __sym0 = __pop_Variant0(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym1.2;
-                let __nt = match super::__action1323::<>(__sym0, __sym1) {
+                let __nt = match super::__action1324::<>(__sym0, __sym1) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -14695,18 +14697,18 @@ mod __parse__Top {
                 __reduce607(__lookahead_start, __symbols, core::marker::PhantomData::<()>)
             }
             608 => {
-                // ParameterList<UntypedParameter, UntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "*", UntypedParameter, ",", KwargParameter<UntypedParameter>, "," => ActionFn(1561);
+                // ParameterList<UntypedParameter, UntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "*", UntypedParameter, ",", KwargParameter<UntypedParameter>, "," => ActionFn(1562);
                 assert!(__symbols.len() >= 7);
                 let __sym6 = __pop_Variant0(__symbols);
                 let __sym5 = __pop_Variant9(__symbols);
                 let __sym4 = __pop_Variant0(__symbols);
-                let __sym3 = __pop_Variant81(__symbols);
+                let __sym3 = __pop_Variant83(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant74(__symbols);
+                let __sym0 = __pop_Variant76(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym6.2;
-                let __nt = match super::__action1561::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6) {
+                let __nt = match super::__action1562::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -14714,20 +14716,20 @@ mod __parse__Top {
                 (7, 201)
             }
             609 => {
-                // ParameterList<UntypedParameter, UntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "/", ",", "*", UntypedParameter, ",", KwargParameter<UntypedParameter>, "," => ActionFn(1562);
+                // ParameterList<UntypedParameter, UntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "/", ",", "*", UntypedParameter, ",", KwargParameter<UntypedParameter>, "," => ActionFn(1563);
                 assert!(__symbols.len() >= 9);
                 let __sym8 = __pop_Variant0(__symbols);
                 let __sym7 = __pop_Variant9(__symbols);
                 let __sym6 = __pop_Variant0(__symbols);
-                let __sym5 = __pop_Variant81(__symbols);
+                let __sym5 = __pop_Variant83(__symbols);
                 let __sym4 = __pop_Variant0(__symbols);
                 let __sym3 = __pop_Variant0(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant74(__symbols);
+                let __sym0 = __pop_Variant76(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym8.2;
-                let __nt = match super::__action1562::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7, __sym8) {
+                let __nt = match super::__action1563::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7, __sym8) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -14735,21 +14737,21 @@ mod __parse__Top {
                 (9, 201)
             }
             610 => {
-                // ParameterList<UntypedParameter, UntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "/", ("," <ParameterDef<UntypedParameter>>)+, ",", "*", UntypedParameter, ",", KwargParameter<UntypedParameter>, "," => ActionFn(1563);
+                // ParameterList<UntypedParameter, UntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "/", ("," <ParameterDef<UntypedParameter>>)+, ",", "*", UntypedParameter, ",", KwargParameter<UntypedParameter>, "," => ActionFn(1564);
                 assert!(__symbols.len() >= 10);
                 let __sym9 = __pop_Variant0(__symbols);
                 let __sym8 = __pop_Variant9(__symbols);
                 let __sym7 = __pop_Variant0(__symbols);
-                let __sym6 = __pop_Variant81(__symbols);
+                let __sym6 = __pop_Variant83(__symbols);
                 let __sym5 = __pop_Variant0(__symbols);
                 let __sym4 = __pop_Variant0(__symbols);
                 let __sym3 = __pop_Variant12(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant74(__symbols);
+                let __sym0 = __pop_Variant76(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym9.2;
-                let __nt = match super::__action1563::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7, __sym8, __sym9) {
+                let __nt = match super::__action1564::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7, __sym8, __sym9) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -14757,17 +14759,17 @@ mod __parse__Top {
                 (10, 201)
             }
             611 => {
-                // ParameterList<UntypedParameter, UntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "*", ",", KwargParameter<UntypedParameter>, "," => ActionFn(1564);
+                // ParameterList<UntypedParameter, UntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "*", ",", KwargParameter<UntypedParameter>, "," => ActionFn(1565);
                 assert!(__symbols.len() >= 6);
                 let __sym5 = __pop_Variant0(__symbols);
                 let __sym4 = __pop_Variant9(__symbols);
                 let __sym3 = __pop_Variant0(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant74(__symbols);
+                let __sym0 = __pop_Variant76(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym5.2;
-                let __nt = match super::__action1564::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5) {
+                let __nt = match super::__action1565::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -14775,7 +14777,7 @@ mod __parse__Top {
                 (6, 201)
             }
             612 => {
-                // ParameterList<UntypedParameter, UntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "/", ",", "*", ",", KwargParameter<UntypedParameter>, "," => ActionFn(1565);
+                // ParameterList<UntypedParameter, UntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "/", ",", "*", ",", KwargParameter<UntypedParameter>, "," => ActionFn(1566);
                 assert!(__symbols.len() >= 8);
                 let __sym7 = __pop_Variant0(__symbols);
                 let __sym6 = __pop_Variant9(__symbols);
@@ -14784,10 +14786,10 @@ mod __parse__Top {
                 let __sym3 = __pop_Variant0(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant74(__symbols);
+                let __sym0 = __pop_Variant76(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym7.2;
-                let __nt = match super::__action1565::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7) {
+                let __nt = match super::__action1566::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -14795,7 +14797,7 @@ mod __parse__Top {
                 (8, 201)
             }
             613 => {
-                // ParameterList<UntypedParameter, UntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "/", ("," <ParameterDef<UntypedParameter>>)+, ",", "*", ",", KwargParameter<UntypedParameter>, "," => ActionFn(1566);
+                // ParameterList<UntypedParameter, UntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "/", ("," <ParameterDef<UntypedParameter>>)+, ",", "*", ",", KwargParameter<UntypedParameter>, "," => ActionFn(1567);
                 assert!(__symbols.len() >= 9);
                 let __sym8 = __pop_Variant0(__symbols);
                 let __sym7 = __pop_Variant9(__symbols);
@@ -14805,10 +14807,10 @@ mod __parse__Top {
                 let __sym3 = __pop_Variant12(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant74(__symbols);
+                let __sym0 = __pop_Variant76(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym8.2;
-                let __nt = match super::__action1566::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7, __sym8) {
+                let __nt = match super::__action1567::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7, __sym8) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -14816,19 +14818,19 @@ mod __parse__Top {
                 (9, 201)
             }
             614 => {
-                // ParameterList<UntypedParameter, UntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "*", UntypedParameter, ("," <ParameterDef<UntypedParameter>>)+, ",", KwargParameter<UntypedParameter>, "," => ActionFn(1567);
+                // ParameterList<UntypedParameter, UntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "*", UntypedParameter, ("," <ParameterDef<UntypedParameter>>)+, ",", KwargParameter<UntypedParameter>, "," => ActionFn(1568);
                 assert!(__symbols.len() >= 8);
                 let __sym7 = __pop_Variant0(__symbols);
                 let __sym6 = __pop_Variant9(__symbols);
                 let __sym5 = __pop_Variant0(__symbols);
                 let __sym4 = __pop_Variant12(__symbols);
-                let __sym3 = __pop_Variant81(__symbols);
+                let __sym3 = __pop_Variant83(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant74(__symbols);
+                let __sym0 = __pop_Variant76(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym7.2;
-                let __nt = match super::__action1567::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7) {
+                let __nt = match super::__action1568::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -14836,21 +14838,21 @@ mod __parse__Top {
                 (8, 201)
             }
             615 => {
-                // ParameterList<UntypedParameter, UntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "/", ",", "*", UntypedParameter, ("," <ParameterDef<UntypedParameter>>)+, ",", KwargParameter<UntypedParameter>, "," => ActionFn(1568);
+                // ParameterList<UntypedParameter, UntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "/", ",", "*", UntypedParameter, ("," <ParameterDef<UntypedParameter>>)+, ",", KwargParameter<UntypedParameter>, "," => ActionFn(1569);
                 assert!(__symbols.len() >= 10);
                 let __sym9 = __pop_Variant0(__symbols);
                 let __sym8 = __pop_Variant9(__symbols);
                 let __sym7 = __pop_Variant0(__symbols);
                 let __sym6 = __pop_Variant12(__symbols);
-                let __sym5 = __pop_Variant81(__symbols);
+                let __sym5 = __pop_Variant83(__symbols);
                 let __sym4 = __pop_Variant0(__symbols);
                 let __sym3 = __pop_Variant0(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant74(__symbols);
+                let __sym0 = __pop_Variant76(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym9.2;
-                let __nt = match super::__action1568::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7, __sym8, __sym9) {
+                let __nt = match super::__action1569::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7, __sym8, __sym9) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -14858,22 +14860,22 @@ mod __parse__Top {
                 (10, 201)
             }
             616 => {
-                // ParameterList<UntypedParameter, UntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "/", ("," <ParameterDef<UntypedParameter>>)+, ",", "*", UntypedParameter, ("," <ParameterDef<UntypedParameter>>)+, ",", KwargParameter<UntypedParameter>, "," => ActionFn(1569);
+                // ParameterList<UntypedParameter, UntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "/", ("," <ParameterDef<UntypedParameter>>)+, ",", "*", UntypedParameter, ("," <ParameterDef<UntypedParameter>>)+, ",", KwargParameter<UntypedParameter>, "," => ActionFn(1570);
                 assert!(__symbols.len() >= 11);
                 let __sym10 = __pop_Variant0(__symbols);
                 let __sym9 = __pop_Variant9(__symbols);
                 let __sym8 = __pop_Variant0(__symbols);
                 let __sym7 = __pop_Variant12(__symbols);
-                let __sym6 = __pop_Variant81(__symbols);
+                let __sym6 = __pop_Variant83(__symbols);
                 let __sym5 = __pop_Variant0(__symbols);
                 let __sym4 = __pop_Variant0(__symbols);
                 let __sym3 = __pop_Variant12(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant74(__symbols);
+                let __sym0 = __pop_Variant76(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym10.2;
-                let __nt = match super::__action1569::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7, __sym8, __sym9, __sym10) {
+                let __nt = match super::__action1570::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7, __sym8, __sym9, __sym10) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -14881,7 +14883,7 @@ mod __parse__Top {
                 (11, 201)
             }
             617 => {
-                // ParameterList<UntypedParameter, UntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "*", ("," <ParameterDef<UntypedParameter>>)+, ",", KwargParameter<UntypedParameter>, "," => ActionFn(1570);
+                // ParameterList<UntypedParameter, UntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "*", ("," <ParameterDef<UntypedParameter>>)+, ",", KwargParameter<UntypedParameter>, "," => ActionFn(1571);
                 assert!(__symbols.len() >= 7);
                 let __sym6 = __pop_Variant0(__symbols);
                 let __sym5 = __pop_Variant9(__symbols);
@@ -14889,10 +14891,10 @@ mod __parse__Top {
                 let __sym3 = __pop_Variant12(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant74(__symbols);
+                let __sym0 = __pop_Variant76(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym6.2;
-                let __nt = match super::__action1570::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6) {
+                let __nt = match super::__action1571::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -14900,7 +14902,7 @@ mod __parse__Top {
                 (7, 201)
             }
             618 => {
-                // ParameterList<UntypedParameter, UntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "/", ",", "*", ("," <ParameterDef<UntypedParameter>>)+, ",", KwargParameter<UntypedParameter>, "," => ActionFn(1571);
+                // ParameterList<UntypedParameter, UntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "/", ",", "*", ("," <ParameterDef<UntypedParameter>>)+, ",", KwargParameter<UntypedParameter>, "," => ActionFn(1572);
                 assert!(__symbols.len() >= 9);
                 let __sym8 = __pop_Variant0(__symbols);
                 let __sym7 = __pop_Variant9(__symbols);
@@ -14910,10 +14912,10 @@ mod __parse__Top {
                 let __sym3 = __pop_Variant0(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant74(__symbols);
+                let __sym0 = __pop_Variant76(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym8.2;
-                let __nt = match super::__action1571::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7, __sym8) {
+                let __nt = match super::__action1572::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7, __sym8) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -14921,7 +14923,7 @@ mod __parse__Top {
                 (9, 201)
             }
             619 => {
-                // ParameterList<UntypedParameter, UntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "/", ("," <ParameterDef<UntypedParameter>>)+, ",", "*", ("," <ParameterDef<UntypedParameter>>)+, ",", KwargParameter<UntypedParameter>, "," => ActionFn(1572);
+                // ParameterList<UntypedParameter, UntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "/", ("," <ParameterDef<UntypedParameter>>)+, ",", "*", ("," <ParameterDef<UntypedParameter>>)+, ",", KwargParameter<UntypedParameter>, "," => ActionFn(1573);
                 assert!(__symbols.len() >= 10);
                 let __sym9 = __pop_Variant0(__symbols);
                 let __sym8 = __pop_Variant9(__symbols);
@@ -14932,10 +14934,10 @@ mod __parse__Top {
                 let __sym3 = __pop_Variant12(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant74(__symbols);
+                let __sym0 = __pop_Variant76(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym9.2;
-                let __nt = match super::__action1572::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7, __sym8, __sym9) {
+                let __nt = match super::__action1573::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7, __sym8, __sym9) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -14943,16 +14945,16 @@ mod __parse__Top {
                 (10, 201)
             }
             620 => {
-                // ParameterList<UntypedParameter, UntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "*", UntypedParameter, "," => ActionFn(1573);
+                // ParameterList<UntypedParameter, UntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "*", UntypedParameter, "," => ActionFn(1574);
                 assert!(__symbols.len() >= 5);
                 let __sym4 = __pop_Variant0(__symbols);
-                let __sym3 = __pop_Variant81(__symbols);
+                let __sym3 = __pop_Variant83(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant74(__symbols);
+                let __sym0 = __pop_Variant76(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym4.2;
-                let __nt = match super::__action1573::<>(__sym0, __sym1, __sym2, __sym3, __sym4) {
+                let __nt = match super::__action1574::<>(__sym0, __sym1, __sym2, __sym3, __sym4) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -14960,18 +14962,18 @@ mod __parse__Top {
                 (5, 201)
             }
             621 => {
-                // ParameterList<UntypedParameter, UntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "/", ",", "*", UntypedParameter, "," => ActionFn(1574);
+                // ParameterList<UntypedParameter, UntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "/", ",", "*", UntypedParameter, "," => ActionFn(1575);
                 assert!(__symbols.len() >= 7);
                 let __sym6 = __pop_Variant0(__symbols);
-                let __sym5 = __pop_Variant81(__symbols);
+                let __sym5 = __pop_Variant83(__symbols);
                 let __sym4 = __pop_Variant0(__symbols);
                 let __sym3 = __pop_Variant0(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant74(__symbols);
+                let __sym0 = __pop_Variant76(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym6.2;
-                let __nt = match super::__action1574::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6) {
+                let __nt = match super::__action1575::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -14979,19 +14981,19 @@ mod __parse__Top {
                 (7, 201)
             }
             622 => {
-                // ParameterList<UntypedParameter, UntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "/", ("," <ParameterDef<UntypedParameter>>)+, ",", "*", UntypedParameter, "," => ActionFn(1575);
+                // ParameterList<UntypedParameter, UntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "/", ("," <ParameterDef<UntypedParameter>>)+, ",", "*", UntypedParameter, "," => ActionFn(1576);
                 assert!(__symbols.len() >= 8);
                 let __sym7 = __pop_Variant0(__symbols);
-                let __sym6 = __pop_Variant81(__symbols);
+                let __sym6 = __pop_Variant83(__symbols);
                 let __sym5 = __pop_Variant0(__symbols);
                 let __sym4 = __pop_Variant0(__symbols);
                 let __sym3 = __pop_Variant12(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant74(__symbols);
+                let __sym0 = __pop_Variant76(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym7.2;
-                let __nt = match super::__action1575::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7) {
+                let __nt = match super::__action1576::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -14999,15 +15001,15 @@ mod __parse__Top {
                 (8, 201)
             }
             623 => {
-                // ParameterList<UntypedParameter, UntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "*", "," => ActionFn(1576);
+                // ParameterList<UntypedParameter, UntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "*", "," => ActionFn(1577);
                 assert!(__symbols.len() >= 4);
                 let __sym3 = __pop_Variant0(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant74(__symbols);
+                let __sym0 = __pop_Variant76(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym3.2;
-                let __nt = match super::__action1576::<>(__sym0, __sym1, __sym2, __sym3) {
+                let __nt = match super::__action1577::<>(__sym0, __sym1, __sym2, __sym3) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -15015,17 +15017,17 @@ mod __parse__Top {
                 (4, 201)
             }
             624 => {
-                // ParameterList<UntypedParameter, UntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "/", ",", "*", "," => ActionFn(1577);
+                // ParameterList<UntypedParameter, UntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "/", ",", "*", "," => ActionFn(1578);
                 assert!(__symbols.len() >= 6);
                 let __sym5 = __pop_Variant0(__symbols);
                 let __sym4 = __pop_Variant0(__symbols);
                 let __sym3 = __pop_Variant0(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant74(__symbols);
+                let __sym0 = __pop_Variant76(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym5.2;
-                let __nt = match super::__action1577::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5) {
+                let __nt = match super::__action1578::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -15033,7 +15035,7 @@ mod __parse__Top {
                 (6, 201)
             }
             625 => {
-                // ParameterList<UntypedParameter, UntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "/", ("," <ParameterDef<UntypedParameter>>)+, ",", "*", "," => ActionFn(1578);
+                // ParameterList<UntypedParameter, UntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "/", ("," <ParameterDef<UntypedParameter>>)+, ",", "*", "," => ActionFn(1579);
                 assert!(__symbols.len() >= 7);
                 let __sym6 = __pop_Variant0(__symbols);
                 let __sym5 = __pop_Variant0(__symbols);
@@ -15041,10 +15043,10 @@ mod __parse__Top {
                 let __sym3 = __pop_Variant12(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant74(__symbols);
+                let __sym0 = __pop_Variant76(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym6.2;
-                let __nt = match super::__action1578::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6) {
+                let __nt = match super::__action1579::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -15052,17 +15054,17 @@ mod __parse__Top {
                 (7, 201)
             }
             626 => {
-                // ParameterList<UntypedParameter, UntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "*", UntypedParameter, ("," <ParameterDef<UntypedParameter>>)+, "," => ActionFn(1579);
+                // ParameterList<UntypedParameter, UntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "*", UntypedParameter, ("," <ParameterDef<UntypedParameter>>)+, "," => ActionFn(1580);
                 assert!(__symbols.len() >= 6);
                 let __sym5 = __pop_Variant0(__symbols);
                 let __sym4 = __pop_Variant12(__symbols);
-                let __sym3 = __pop_Variant81(__symbols);
+                let __sym3 = __pop_Variant83(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant74(__symbols);
+                let __sym0 = __pop_Variant76(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym5.2;
-                let __nt = match super::__action1579::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5) {
+                let __nt = match super::__action1580::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -15070,19 +15072,19 @@ mod __parse__Top {
                 (6, 201)
             }
             627 => {
-                // ParameterList<UntypedParameter, UntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "/", ",", "*", UntypedParameter, ("," <ParameterDef<UntypedParameter>>)+, "," => ActionFn(1580);
+                // ParameterList<UntypedParameter, UntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "/", ",", "*", UntypedParameter, ("," <ParameterDef<UntypedParameter>>)+, "," => ActionFn(1581);
                 assert!(__symbols.len() >= 8);
                 let __sym7 = __pop_Variant0(__symbols);
                 let __sym6 = __pop_Variant12(__symbols);
-                let __sym5 = __pop_Variant81(__symbols);
+                let __sym5 = __pop_Variant83(__symbols);
                 let __sym4 = __pop_Variant0(__symbols);
                 let __sym3 = __pop_Variant0(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant74(__symbols);
+                let __sym0 = __pop_Variant76(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym7.2;
-                let __nt = match super::__action1580::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7) {
+                let __nt = match super::__action1581::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -15090,20 +15092,20 @@ mod __parse__Top {
                 (8, 201)
             }
             628 => {
-                // ParameterList<UntypedParameter, UntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "/", ("," <ParameterDef<UntypedParameter>>)+, ",", "*", UntypedParameter, ("," <ParameterDef<UntypedParameter>>)+, "," => ActionFn(1581);
+                // ParameterList<UntypedParameter, UntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "/", ("," <ParameterDef<UntypedParameter>>)+, ",", "*", UntypedParameter, ("," <ParameterDef<UntypedParameter>>)+, "," => ActionFn(1582);
                 assert!(__symbols.len() >= 9);
                 let __sym8 = __pop_Variant0(__symbols);
                 let __sym7 = __pop_Variant12(__symbols);
-                let __sym6 = __pop_Variant81(__symbols);
+                let __sym6 = __pop_Variant83(__symbols);
                 let __sym5 = __pop_Variant0(__symbols);
                 let __sym4 = __pop_Variant0(__symbols);
                 let __sym3 = __pop_Variant12(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant74(__symbols);
+                let __sym0 = __pop_Variant76(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym8.2;
-                let __nt = match super::__action1581::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7, __sym8) {
+                let __nt = match super::__action1582::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7, __sym8) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -15111,16 +15113,16 @@ mod __parse__Top {
                 (9, 201)
             }
             629 => {
-                // ParameterList<UntypedParameter, UntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "*", ("," <ParameterDef<UntypedParameter>>)+, "," => ActionFn(1582);
+                // ParameterList<UntypedParameter, UntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "*", ("," <ParameterDef<UntypedParameter>>)+, "," => ActionFn(1583);
                 assert!(__symbols.len() >= 5);
                 let __sym4 = __pop_Variant0(__symbols);
                 let __sym3 = __pop_Variant12(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant74(__symbols);
+                let __sym0 = __pop_Variant76(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym4.2;
-                let __nt = match super::__action1582::<>(__sym0, __sym1, __sym2, __sym3, __sym4) {
+                let __nt = match super::__action1583::<>(__sym0, __sym1, __sym2, __sym3, __sym4) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -15128,7 +15130,7 @@ mod __parse__Top {
                 (5, 201)
             }
             630 => {
-                // ParameterList<UntypedParameter, UntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "/", ",", "*", ("," <ParameterDef<UntypedParameter>>)+, "," => ActionFn(1583);
+                // ParameterList<UntypedParameter, UntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "/", ",", "*", ("," <ParameterDef<UntypedParameter>>)+, "," => ActionFn(1584);
                 assert!(__symbols.len() >= 7);
                 let __sym6 = __pop_Variant0(__symbols);
                 let __sym5 = __pop_Variant12(__symbols);
@@ -15136,10 +15138,10 @@ mod __parse__Top {
                 let __sym3 = __pop_Variant0(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant74(__symbols);
+                let __sym0 = __pop_Variant76(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym6.2;
-                let __nt = match super::__action1583::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6) {
+                let __nt = match super::__action1584::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -15147,7 +15149,7 @@ mod __parse__Top {
                 (7, 201)
             }
             631 => {
-                // ParameterList<UntypedParameter, UntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "/", ("," <ParameterDef<UntypedParameter>>)+, ",", "*", ("," <ParameterDef<UntypedParameter>>)+, "," => ActionFn(1584);
+                // ParameterList<UntypedParameter, UntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "/", ("," <ParameterDef<UntypedParameter>>)+, ",", "*", ("," <ParameterDef<UntypedParameter>>)+, "," => ActionFn(1585);
                 assert!(__symbols.len() >= 8);
                 let __sym7 = __pop_Variant0(__symbols);
                 let __sym6 = __pop_Variant12(__symbols);
@@ -15156,10 +15158,10 @@ mod __parse__Top {
                 let __sym3 = __pop_Variant12(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant74(__symbols);
+                let __sym0 = __pop_Variant76(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym7.2;
-                let __nt = match super::__action1584::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7) {
+                let __nt = match super::__action1585::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -15167,13 +15169,13 @@ mod __parse__Top {
                 (8, 201)
             }
             632 => {
-                // ParameterList<UntypedParameter, UntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, "," => ActionFn(1585);
+                // ParameterList<UntypedParameter, UntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, "," => ActionFn(1586);
                 assert!(__symbols.len() >= 2);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant74(__symbols);
+                let __sym0 = __pop_Variant76(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym1.2;
-                let __nt = match super::__action1585::<>(__sym0, __sym1) {
+                let __nt = match super::__action1586::<>(__sym0, __sym1) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -15181,15 +15183,15 @@ mod __parse__Top {
                 (2, 201)
             }
             633 => {
-                // ParameterList<UntypedParameter, UntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "/", "," => ActionFn(1586);
+                // ParameterList<UntypedParameter, UntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "/", "," => ActionFn(1587);
                 assert!(__symbols.len() >= 4);
                 let __sym3 = __pop_Variant0(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant74(__symbols);
+                let __sym0 = __pop_Variant76(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym3.2;
-                let __nt = match super::__action1586::<>(__sym0, __sym1, __sym2, __sym3) {
+                let __nt = match super::__action1587::<>(__sym0, __sym1, __sym2, __sym3) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -15197,16 +15199,16 @@ mod __parse__Top {
                 (4, 201)
             }
             634 => {
-                // ParameterList<UntypedParameter, UntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "/", ("," <ParameterDef<UntypedParameter>>)+, "," => ActionFn(1587);
+                // ParameterList<UntypedParameter, UntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "/", ("," <ParameterDef<UntypedParameter>>)+, "," => ActionFn(1588);
                 assert!(__symbols.len() >= 5);
                 let __sym4 = __pop_Variant0(__symbols);
                 let __sym3 = __pop_Variant12(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant74(__symbols);
+                let __sym0 = __pop_Variant76(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym4.2;
-                let __nt = match super::__action1587::<>(__sym0, __sym1, __sym2, __sym3, __sym4) {
+                let __nt = match super::__action1588::<>(__sym0, __sym1, __sym2, __sym3, __sym4) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -15214,17 +15216,17 @@ mod __parse__Top {
                 (5, 201)
             }
             635 => {
-                // ParameterList<UntypedParameter, UntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "*", UntypedParameter, ",", KwargParameter<UntypedParameter> => ActionFn(1588);
+                // ParameterList<UntypedParameter, UntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "*", UntypedParameter, ",", KwargParameter<UntypedParameter> => ActionFn(1589);
                 assert!(__symbols.len() >= 6);
                 let __sym5 = __pop_Variant9(__symbols);
                 let __sym4 = __pop_Variant0(__symbols);
-                let __sym3 = __pop_Variant81(__symbols);
+                let __sym3 = __pop_Variant83(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant74(__symbols);
+                let __sym0 = __pop_Variant76(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym5.2;
-                let __nt = match super::__action1588::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5) {
+                let __nt = match super::__action1589::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -15232,19 +15234,19 @@ mod __parse__Top {
                 (6, 201)
             }
             636 => {
-                // ParameterList<UntypedParameter, UntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "/", ",", "*", UntypedParameter, ",", KwargParameter<UntypedParameter> => ActionFn(1589);
+                // ParameterList<UntypedParameter, UntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "/", ",", "*", UntypedParameter, ",", KwargParameter<UntypedParameter> => ActionFn(1590);
                 assert!(__symbols.len() >= 8);
                 let __sym7 = __pop_Variant9(__symbols);
                 let __sym6 = __pop_Variant0(__symbols);
-                let __sym5 = __pop_Variant81(__symbols);
+                let __sym5 = __pop_Variant83(__symbols);
                 let __sym4 = __pop_Variant0(__symbols);
                 let __sym3 = __pop_Variant0(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant74(__symbols);
+                let __sym0 = __pop_Variant76(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym7.2;
-                let __nt = match super::__action1589::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7) {
+                let __nt = match super::__action1590::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -15252,20 +15254,20 @@ mod __parse__Top {
                 (8, 201)
             }
             637 => {
-                // ParameterList<UntypedParameter, UntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "/", ("," <ParameterDef<UntypedParameter>>)+, ",", "*", UntypedParameter, ",", KwargParameter<UntypedParameter> => ActionFn(1590);
+                // ParameterList<UntypedParameter, UntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "/", ("," <ParameterDef<UntypedParameter>>)+, ",", "*", UntypedParameter, ",", KwargParameter<UntypedParameter> => ActionFn(1591);
                 assert!(__symbols.len() >= 9);
                 let __sym8 = __pop_Variant9(__symbols);
                 let __sym7 = __pop_Variant0(__symbols);
-                let __sym6 = __pop_Variant81(__symbols);
+                let __sym6 = __pop_Variant83(__symbols);
                 let __sym5 = __pop_Variant0(__symbols);
                 let __sym4 = __pop_Variant0(__symbols);
                 let __sym3 = __pop_Variant12(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant74(__symbols);
+                let __sym0 = __pop_Variant76(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym8.2;
-                let __nt = match super::__action1590::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7, __sym8) {
+                let __nt = match super::__action1591::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7, __sym8) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -15273,16 +15275,16 @@ mod __parse__Top {
                 (9, 201)
             }
             638 => {
-                // ParameterList<UntypedParameter, UntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "*", ",", KwargParameter<UntypedParameter> => ActionFn(1591);
+                // ParameterList<UntypedParameter, UntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "*", ",", KwargParameter<UntypedParameter> => ActionFn(1592);
                 assert!(__symbols.len() >= 5);
                 let __sym4 = __pop_Variant9(__symbols);
                 let __sym3 = __pop_Variant0(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant74(__symbols);
+                let __sym0 = __pop_Variant76(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym4.2;
-                let __nt = match super::__action1591::<>(__sym0, __sym1, __sym2, __sym3, __sym4) {
+                let __nt = match super::__action1592::<>(__sym0, __sym1, __sym2, __sym3, __sym4) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -15290,7 +15292,7 @@ mod __parse__Top {
                 (5, 201)
             }
             639 => {
-                // ParameterList<UntypedParameter, UntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "/", ",", "*", ",", KwargParameter<UntypedParameter> => ActionFn(1592);
+                // ParameterList<UntypedParameter, UntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "/", ",", "*", ",", KwargParameter<UntypedParameter> => ActionFn(1593);
                 assert!(__symbols.len() >= 7);
                 let __sym6 = __pop_Variant9(__symbols);
                 let __sym5 = __pop_Variant0(__symbols);
@@ -15298,10 +15300,10 @@ mod __parse__Top {
                 let __sym3 = __pop_Variant0(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant74(__symbols);
+                let __sym0 = __pop_Variant76(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym6.2;
-                let __nt = match super::__action1592::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6) {
+                let __nt = match super::__action1593::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -15309,7 +15311,7 @@ mod __parse__Top {
                 (7, 201)
             }
             640 => {
-                // ParameterList<UntypedParameter, UntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "/", ("," <ParameterDef<UntypedParameter>>)+, ",", "*", ",", KwargParameter<UntypedParameter> => ActionFn(1593);
+                // ParameterList<UntypedParameter, UntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "/", ("," <ParameterDef<UntypedParameter>>)+, ",", "*", ",", KwargParameter<UntypedParameter> => ActionFn(1594);
                 assert!(__symbols.len() >= 8);
                 let __sym7 = __pop_Variant9(__symbols);
                 let __sym6 = __pop_Variant0(__symbols);
@@ -15318,10 +15320,10 @@ mod __parse__Top {
                 let __sym3 = __pop_Variant12(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant74(__symbols);
+                let __sym0 = __pop_Variant76(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym7.2;
-                let __nt = match super::__action1593::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7) {
+                let __nt = match super::__action1594::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -15329,18 +15331,18 @@ mod __parse__Top {
                 (8, 201)
             }
             641 => {
-                // ParameterList<UntypedParameter, UntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "*", UntypedParameter, ("," <ParameterDef<UntypedParameter>>)+, ",", KwargParameter<UntypedParameter> => ActionFn(1594);
+                // ParameterList<UntypedParameter, UntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "*", UntypedParameter, ("," <ParameterDef<UntypedParameter>>)+, ",", KwargParameter<UntypedParameter> => ActionFn(1595);
                 assert!(__symbols.len() >= 7);
                 let __sym6 = __pop_Variant9(__symbols);
                 let __sym5 = __pop_Variant0(__symbols);
                 let __sym4 = __pop_Variant12(__symbols);
-                let __sym3 = __pop_Variant81(__symbols);
+                let __sym3 = __pop_Variant83(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant74(__symbols);
+                let __sym0 = __pop_Variant76(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym6.2;
-                let __nt = match super::__action1594::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6) {
+                let __nt = match super::__action1595::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -15348,20 +15350,20 @@ mod __parse__Top {
                 (7, 201)
             }
             642 => {
-                // ParameterList<UntypedParameter, UntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "/", ",", "*", UntypedParameter, ("," <ParameterDef<UntypedParameter>>)+, ",", KwargParameter<UntypedParameter> => ActionFn(1595);
+                // ParameterList<UntypedParameter, UntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "/", ",", "*", UntypedParameter, ("," <ParameterDef<UntypedParameter>>)+, ",", KwargParameter<UntypedParameter> => ActionFn(1596);
                 assert!(__symbols.len() >= 9);
                 let __sym8 = __pop_Variant9(__symbols);
                 let __sym7 = __pop_Variant0(__symbols);
                 let __sym6 = __pop_Variant12(__symbols);
-                let __sym5 = __pop_Variant81(__symbols);
+                let __sym5 = __pop_Variant83(__symbols);
                 let __sym4 = __pop_Variant0(__symbols);
                 let __sym3 = __pop_Variant0(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant74(__symbols);
+                let __sym0 = __pop_Variant76(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym8.2;
-                let __nt = match super::__action1595::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7, __sym8) {
+                let __nt = match super::__action1596::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7, __sym8) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -15369,21 +15371,21 @@ mod __parse__Top {
                 (9, 201)
             }
             643 => {
-                // ParameterList<UntypedParameter, UntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "/", ("," <ParameterDef<UntypedParameter>>)+, ",", "*", UntypedParameter, ("," <ParameterDef<UntypedParameter>>)+, ",", KwargParameter<UntypedParameter> => ActionFn(1596);
+                // ParameterList<UntypedParameter, UntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "/", ("," <ParameterDef<UntypedParameter>>)+, ",", "*", UntypedParameter, ("," <ParameterDef<UntypedParameter>>)+, ",", KwargParameter<UntypedParameter> => ActionFn(1597);
                 assert!(__symbols.len() >= 10);
                 let __sym9 = __pop_Variant9(__symbols);
                 let __sym8 = __pop_Variant0(__symbols);
                 let __sym7 = __pop_Variant12(__symbols);
-                let __sym6 = __pop_Variant81(__symbols);
+                let __sym6 = __pop_Variant83(__symbols);
                 let __sym5 = __pop_Variant0(__symbols);
                 let __sym4 = __pop_Variant0(__symbols);
                 let __sym3 = __pop_Variant12(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant74(__symbols);
+                let __sym0 = __pop_Variant76(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym9.2;
-                let __nt = match super::__action1596::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7, __sym8, __sym9) {
+                let __nt = match super::__action1597::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7, __sym8, __sym9) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -15391,17 +15393,17 @@ mod __parse__Top {
                 (10, 201)
             }
             644 => {
-                // ParameterList<UntypedParameter, UntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "*", ("," <ParameterDef<UntypedParameter>>)+, ",", KwargParameter<UntypedParameter> => ActionFn(1597);
+                // ParameterList<UntypedParameter, UntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "*", ("," <ParameterDef<UntypedParameter>>)+, ",", KwargParameter<UntypedParameter> => ActionFn(1598);
                 assert!(__symbols.len() >= 6);
                 let __sym5 = __pop_Variant9(__symbols);
                 let __sym4 = __pop_Variant0(__symbols);
                 let __sym3 = __pop_Variant12(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant74(__symbols);
+                let __sym0 = __pop_Variant76(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym5.2;
-                let __nt = match super::__action1597::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5) {
+                let __nt = match super::__action1598::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -15409,7 +15411,7 @@ mod __parse__Top {
                 (6, 201)
             }
             645 => {
-                // ParameterList<UntypedParameter, UntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "/", ",", "*", ("," <ParameterDef<UntypedParameter>>)+, ",", KwargParameter<UntypedParameter> => ActionFn(1598);
+                // ParameterList<UntypedParameter, UntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "/", ",", "*", ("," <ParameterDef<UntypedParameter>>)+, ",", KwargParameter<UntypedParameter> => ActionFn(1599);
                 assert!(__symbols.len() >= 8);
                 let __sym7 = __pop_Variant9(__symbols);
                 let __sym6 = __pop_Variant0(__symbols);
@@ -15418,10 +15420,10 @@ mod __parse__Top {
                 let __sym3 = __pop_Variant0(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant74(__symbols);
+                let __sym0 = __pop_Variant76(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym7.2;
-                let __nt = match super::__action1598::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7) {
+                let __nt = match super::__action1599::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -15429,7 +15431,7 @@ mod __parse__Top {
                 (8, 201)
             }
             646 => {
-                // ParameterList<UntypedParameter, UntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "/", ("," <ParameterDef<UntypedParameter>>)+, ",", "*", ("," <ParameterDef<UntypedParameter>>)+, ",", KwargParameter<UntypedParameter> => ActionFn(1599);
+                // ParameterList<UntypedParameter, UntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "/", ("," <ParameterDef<UntypedParameter>>)+, ",", "*", ("," <ParameterDef<UntypedParameter>>)+, ",", KwargParameter<UntypedParameter> => ActionFn(1600);
                 assert!(__symbols.len() >= 9);
                 let __sym8 = __pop_Variant9(__symbols);
                 let __sym7 = __pop_Variant0(__symbols);
@@ -15439,10 +15441,10 @@ mod __parse__Top {
                 let __sym3 = __pop_Variant12(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant74(__symbols);
+                let __sym0 = __pop_Variant76(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym8.2;
-                let __nt = match super::__action1599::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7, __sym8) {
+                let __nt = match super::__action1600::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7, __sym8) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -15450,15 +15452,15 @@ mod __parse__Top {
                 (9, 201)
             }
             647 => {
-                // ParameterList<UntypedParameter, UntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "*", UntypedParameter => ActionFn(1600);
+                // ParameterList<UntypedParameter, UntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "*", UntypedParameter => ActionFn(1601);
                 assert!(__symbols.len() >= 4);
-                let __sym3 = __pop_Variant81(__symbols);
+                let __sym3 = __pop_Variant83(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant74(__symbols);
+                let __sym0 = __pop_Variant76(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym3.2;
-                let __nt = match super::__action1600::<>(__sym0, __sym1, __sym2, __sym3) {
+                let __nt = match super::__action1601::<>(__sym0, __sym1, __sym2, __sym3) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -15466,17 +15468,17 @@ mod __parse__Top {
                 (4, 201)
             }
             648 => {
-                // ParameterList<UntypedParameter, UntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "/", ",", "*", UntypedParameter => ActionFn(1601);
+                // ParameterList<UntypedParameter, UntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "/", ",", "*", UntypedParameter => ActionFn(1602);
                 assert!(__symbols.len() >= 6);
-                let __sym5 = __pop_Variant81(__symbols);
+                let __sym5 = __pop_Variant83(__symbols);
                 let __sym4 = __pop_Variant0(__symbols);
                 let __sym3 = __pop_Variant0(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant74(__symbols);
+                let __sym0 = __pop_Variant76(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym5.2;
-                let __nt = match super::__action1601::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5) {
+                let __nt = match super::__action1602::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -15484,18 +15486,18 @@ mod __parse__Top {
                 (6, 201)
             }
             649 => {
-                // ParameterList<UntypedParameter, UntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "/", ("," <ParameterDef<UntypedParameter>>)+, ",", "*", UntypedParameter => ActionFn(1602);
+                // ParameterList<UntypedParameter, UntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "/", ("," <ParameterDef<UntypedParameter>>)+, ",", "*", UntypedParameter => ActionFn(1603);
                 assert!(__symbols.len() >= 7);
-                let __sym6 = __pop_Variant81(__symbols);
+                let __sym6 = __pop_Variant83(__symbols);
                 let __sym5 = __pop_Variant0(__symbols);
                 let __sym4 = __pop_Variant0(__symbols);
                 let __sym3 = __pop_Variant12(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant74(__symbols);
+                let __sym0 = __pop_Variant76(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym6.2;
-                let __nt = match super::__action1602::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6) {
+                let __nt = match super::__action1603::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -15503,14 +15505,14 @@ mod __parse__Top {
                 (7, 201)
             }
             650 => {
-                // ParameterList<UntypedParameter, UntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "*" => ActionFn(1603);
+                // ParameterList<UntypedParameter, UntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "*" => ActionFn(1604);
                 assert!(__symbols.len() >= 3);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant74(__symbols);
+                let __sym0 = __pop_Variant76(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym2.2;
-                let __nt = match super::__action1603::<>(__sym0, __sym1, __sym2) {
+                let __nt = match super::__action1604::<>(__sym0, __sym1, __sym2) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -15518,16 +15520,16 @@ mod __parse__Top {
                 (3, 201)
             }
             651 => {
-                // ParameterList<UntypedParameter, UntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "/", ",", "*" => ActionFn(1604);
+                // ParameterList<UntypedParameter, UntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "/", ",", "*" => ActionFn(1605);
                 assert!(__symbols.len() >= 5);
                 let __sym4 = __pop_Variant0(__symbols);
                 let __sym3 = __pop_Variant0(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant74(__symbols);
+                let __sym0 = __pop_Variant76(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym4.2;
-                let __nt = match super::__action1604::<>(__sym0, __sym1, __sym2, __sym3, __sym4) {
+                let __nt = match super::__action1605::<>(__sym0, __sym1, __sym2, __sym3, __sym4) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -15535,17 +15537,17 @@ mod __parse__Top {
                 (5, 201)
             }
             652 => {
-                // ParameterList<UntypedParameter, UntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "/", ("," <ParameterDef<UntypedParameter>>)+, ",", "*" => ActionFn(1605);
+                // ParameterList<UntypedParameter, UntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "/", ("," <ParameterDef<UntypedParameter>>)+, ",", "*" => ActionFn(1606);
                 assert!(__symbols.len() >= 6);
                 let __sym5 = __pop_Variant0(__symbols);
                 let __sym4 = __pop_Variant0(__symbols);
                 let __sym3 = __pop_Variant12(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant74(__symbols);
+                let __sym0 = __pop_Variant76(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym5.2;
-                let __nt = match super::__action1605::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5) {
+                let __nt = match super::__action1606::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -15553,16 +15555,16 @@ mod __parse__Top {
                 (6, 201)
             }
             653 => {
-                // ParameterList<UntypedParameter, UntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "*", UntypedParameter, ("," <ParameterDef<UntypedParameter>>)+ => ActionFn(1606);
+                // ParameterList<UntypedParameter, UntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "*", UntypedParameter, ("," <ParameterDef<UntypedParameter>>)+ => ActionFn(1607);
                 assert!(__symbols.len() >= 5);
                 let __sym4 = __pop_Variant12(__symbols);
-                let __sym3 = __pop_Variant81(__symbols);
+                let __sym3 = __pop_Variant83(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant74(__symbols);
+                let __sym0 = __pop_Variant76(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym4.2;
-                let __nt = match super::__action1606::<>(__sym0, __sym1, __sym2, __sym3, __sym4) {
+                let __nt = match super::__action1607::<>(__sym0, __sym1, __sym2, __sym3, __sym4) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -15570,18 +15572,18 @@ mod __parse__Top {
                 (5, 201)
             }
             654 => {
-                // ParameterList<UntypedParameter, UntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "/", ",", "*", UntypedParameter, ("," <ParameterDef<UntypedParameter>>)+ => ActionFn(1607);
+                // ParameterList<UntypedParameter, UntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "/", ",", "*", UntypedParameter, ("," <ParameterDef<UntypedParameter>>)+ => ActionFn(1608);
                 assert!(__symbols.len() >= 7);
                 let __sym6 = __pop_Variant12(__symbols);
-                let __sym5 = __pop_Variant81(__symbols);
+                let __sym5 = __pop_Variant83(__symbols);
                 let __sym4 = __pop_Variant0(__symbols);
                 let __sym3 = __pop_Variant0(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant74(__symbols);
+                let __sym0 = __pop_Variant76(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym6.2;
-                let __nt = match super::__action1607::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6) {
+                let __nt = match super::__action1608::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -15589,19 +15591,19 @@ mod __parse__Top {
                 (7, 201)
             }
             655 => {
-                // ParameterList<UntypedParameter, UntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "/", ("," <ParameterDef<UntypedParameter>>)+, ",", "*", UntypedParameter, ("," <ParameterDef<UntypedParameter>>)+ => ActionFn(1608);
+                // ParameterList<UntypedParameter, UntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "/", ("," <ParameterDef<UntypedParameter>>)+, ",", "*", UntypedParameter, ("," <ParameterDef<UntypedParameter>>)+ => ActionFn(1609);
                 assert!(__symbols.len() >= 8);
                 let __sym7 = __pop_Variant12(__symbols);
-                let __sym6 = __pop_Variant81(__symbols);
+                let __sym6 = __pop_Variant83(__symbols);
                 let __sym5 = __pop_Variant0(__symbols);
                 let __sym4 = __pop_Variant0(__symbols);
                 let __sym3 = __pop_Variant12(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant74(__symbols);
+                let __sym0 = __pop_Variant76(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym7.2;
-                let __nt = match super::__action1608::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7) {
+                let __nt = match super::__action1609::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -15609,15 +15611,15 @@ mod __parse__Top {
                 (8, 201)
             }
             656 => {
-                // ParameterList<UntypedParameter, UntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "*", ("," <ParameterDef<UntypedParameter>>)+ => ActionFn(1609);
+                // ParameterList<UntypedParameter, UntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "*", ("," <ParameterDef<UntypedParameter>>)+ => ActionFn(1610);
                 assert!(__symbols.len() >= 4);
                 let __sym3 = __pop_Variant12(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant74(__symbols);
+                let __sym0 = __pop_Variant76(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym3.2;
-                let __nt = match super::__action1609::<>(__sym0, __sym1, __sym2, __sym3) {
+                let __nt = match super::__action1610::<>(__sym0, __sym1, __sym2, __sym3) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -15625,17 +15627,17 @@ mod __parse__Top {
                 (4, 201)
             }
             657 => {
-                // ParameterList<UntypedParameter, UntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "/", ",", "*", ("," <ParameterDef<UntypedParameter>>)+ => ActionFn(1610);
+                // ParameterList<UntypedParameter, UntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "/", ",", "*", ("," <ParameterDef<UntypedParameter>>)+ => ActionFn(1611);
                 assert!(__symbols.len() >= 6);
                 let __sym5 = __pop_Variant12(__symbols);
                 let __sym4 = __pop_Variant0(__symbols);
                 let __sym3 = __pop_Variant0(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant74(__symbols);
+                let __sym0 = __pop_Variant76(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym5.2;
-                let __nt = match super::__action1610::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5) {
+                let __nt = match super::__action1611::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -15643,7 +15645,7 @@ mod __parse__Top {
                 (6, 201)
             }
             658 => {
-                // ParameterList<UntypedParameter, UntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "/", ("," <ParameterDef<UntypedParameter>>)+, ",", "*", ("," <ParameterDef<UntypedParameter>>)+ => ActionFn(1611);
+                // ParameterList<UntypedParameter, UntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "/", ("," <ParameterDef<UntypedParameter>>)+, ",", "*", ("," <ParameterDef<UntypedParameter>>)+ => ActionFn(1612);
                 assert!(__symbols.len() >= 7);
                 let __sym6 = __pop_Variant12(__symbols);
                 let __sym5 = __pop_Variant0(__symbols);
@@ -15651,10 +15653,10 @@ mod __parse__Top {
                 let __sym3 = __pop_Variant12(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant74(__symbols);
+                let __sym0 = __pop_Variant76(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym6.2;
-                let __nt = match super::__action1611::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6) {
+                let __nt = match super::__action1612::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -15662,11 +15664,11 @@ mod __parse__Top {
                 (7, 201)
             }
             659 => {
-                // ParameterList<UntypedParameter, UntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>> => ActionFn(1612);
-                let __sym0 = __pop_Variant74(__symbols);
+                // ParameterList<UntypedParameter, UntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>> => ActionFn(1613);
+                let __sym0 = __pop_Variant76(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym0.2;
-                let __nt = match super::__action1612::<>(__sym0) {
+                let __nt = match super::__action1613::<>(__sym0) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -15674,14 +15676,14 @@ mod __parse__Top {
                 (1, 201)
             }
             660 => {
-                // ParameterList<UntypedParameter, UntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "/" => ActionFn(1613);
+                // ParameterList<UntypedParameter, UntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "/" => ActionFn(1614);
                 assert!(__symbols.len() >= 3);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant74(__symbols);
+                let __sym0 = __pop_Variant76(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym2.2;
-                let __nt = match super::__action1613::<>(__sym0, __sym1, __sym2) {
+                let __nt = match super::__action1614::<>(__sym0, __sym1, __sym2) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -15689,28 +15691,12 @@ mod __parse__Top {
                 (3, 201)
             }
             661 => {
-                // ParameterList<UntypedParameter, UntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "/", ("," <ParameterDef<UntypedParameter>>)+ => ActionFn(1614);
+                // ParameterList<UntypedParameter, UntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "/", ("," <ParameterDef<UntypedParameter>>)+ => ActionFn(1615);
                 assert!(__symbols.len() >= 4);
                 let __sym3 = __pop_Variant12(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant74(__symbols);
-                let __start = __sym0.0;
-                let __end = __sym3.2;
-                let __nt = match super::__action1614::<>(__sym0, __sym1, __sym2, __sym3) {
-                    Ok(v) => v,
-                    Err(e) => return Some(Err(e)),
-                };
-                __symbols.push((__start, __Symbol::Variant44(__nt), __end));
-                (4, 201)
-            }
-            662 => {
-                // ParameterList<UntypedParameter, UntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", KwargParameter<UntypedParameter>, "," => ActionFn(1615);
-                assert!(__symbols.len() >= 4);
-                let __sym3 = __pop_Variant0(__symbols);
-                let __sym2 = __pop_Variant9(__symbols);
-                let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant74(__symbols);
+                let __sym0 = __pop_Variant76(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym3.2;
                 let __nt = match super::__action1615::<>(__sym0, __sym1, __sym2, __sym3) {
@@ -15720,18 +15706,34 @@ mod __parse__Top {
                 __symbols.push((__start, __Symbol::Variant44(__nt), __end));
                 (4, 201)
             }
+            662 => {
+                // ParameterList<UntypedParameter, UntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", KwargParameter<UntypedParameter>, "," => ActionFn(1616);
+                assert!(__symbols.len() >= 4);
+                let __sym3 = __pop_Variant0(__symbols);
+                let __sym2 = __pop_Variant9(__symbols);
+                let __sym1 = __pop_Variant0(__symbols);
+                let __sym0 = __pop_Variant76(__symbols);
+                let __start = __sym0.0;
+                let __end = __sym3.2;
+                let __nt = match super::__action1616::<>(__sym0, __sym1, __sym2, __sym3) {
+                    Ok(v) => v,
+                    Err(e) => return Some(Err(e)),
+                };
+                __symbols.push((__start, __Symbol::Variant44(__nt), __end));
+                (4, 201)
+            }
             663 => {
-                // ParameterList<UntypedParameter, UntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "/", ",", KwargParameter<UntypedParameter>, "," => ActionFn(1616);
+                // ParameterList<UntypedParameter, UntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "/", ",", KwargParameter<UntypedParameter>, "," => ActionFn(1617);
                 assert!(__symbols.len() >= 6);
                 let __sym5 = __pop_Variant0(__symbols);
                 let __sym4 = __pop_Variant9(__symbols);
                 let __sym3 = __pop_Variant0(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant74(__symbols);
+                let __sym0 = __pop_Variant76(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym5.2;
-                let __nt = match super::__action1616::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5) {
+                let __nt = match super::__action1617::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -15739,7 +15741,7 @@ mod __parse__Top {
                 (6, 201)
             }
             664 => {
-                // ParameterList<UntypedParameter, UntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "/", ("," <ParameterDef<UntypedParameter>>)+, ",", KwargParameter<UntypedParameter>, "," => ActionFn(1617);
+                // ParameterList<UntypedParameter, UntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "/", ("," <ParameterDef<UntypedParameter>>)+, ",", KwargParameter<UntypedParameter>, "," => ActionFn(1618);
                 assert!(__symbols.len() >= 7);
                 let __sym6 = __pop_Variant0(__symbols);
                 let __sym5 = __pop_Variant9(__symbols);
@@ -15747,10 +15749,10 @@ mod __parse__Top {
                 let __sym3 = __pop_Variant12(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant74(__symbols);
+                let __sym0 = __pop_Variant76(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym6.2;
-                let __nt = match super::__action1617::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6) {
+                let __nt = match super::__action1618::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -15758,14 +15760,14 @@ mod __parse__Top {
                 (7, 201)
             }
             665 => {
-                // ParameterList<UntypedParameter, UntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", KwargParameter<UntypedParameter> => ActionFn(1618);
+                // ParameterList<UntypedParameter, UntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", KwargParameter<UntypedParameter> => ActionFn(1619);
                 assert!(__symbols.len() >= 3);
                 let __sym2 = __pop_Variant9(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant74(__symbols);
+                let __sym0 = __pop_Variant76(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym2.2;
-                let __nt = match super::__action1618::<>(__sym0, __sym1, __sym2) {
+                let __nt = match super::__action1619::<>(__sym0, __sym1, __sym2) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -15773,16 +15775,16 @@ mod __parse__Top {
                 (3, 201)
             }
             666 => {
-                // ParameterList<UntypedParameter, UntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "/", ",", KwargParameter<UntypedParameter> => ActionFn(1619);
+                // ParameterList<UntypedParameter, UntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "/", ",", KwargParameter<UntypedParameter> => ActionFn(1620);
                 assert!(__symbols.len() >= 5);
                 let __sym4 = __pop_Variant9(__symbols);
                 let __sym3 = __pop_Variant0(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant74(__symbols);
+                let __sym0 = __pop_Variant76(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym4.2;
-                let __nt = match super::__action1619::<>(__sym0, __sym1, __sym2, __sym3, __sym4) {
+                let __nt = match super::__action1620::<>(__sym0, __sym1, __sym2, __sym3, __sym4) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -15790,17 +15792,17 @@ mod __parse__Top {
                 (5, 201)
             }
             667 => {
-                // ParameterList<UntypedParameter, UntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "/", ("," <ParameterDef<UntypedParameter>>)+, ",", KwargParameter<UntypedParameter> => ActionFn(1620);
+                // ParameterList<UntypedParameter, UntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>>, ",", "/", ("," <ParameterDef<UntypedParameter>>)+, ",", KwargParameter<UntypedParameter> => ActionFn(1621);
                 assert!(__symbols.len() >= 6);
                 let __sym5 = __pop_Variant9(__symbols);
                 let __sym4 = __pop_Variant0(__symbols);
                 let __sym3 = __pop_Variant12(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
-                let __sym0 = __pop_Variant74(__symbols);
+                let __sym0 = __pop_Variant76(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym5.2;
-                let __nt = match super::__action1620::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5) {
+                let __nt = match super::__action1621::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -15808,16 +15810,16 @@ mod __parse__Top {
                 (6, 201)
             }
             668 => {
-                // ParameterList<UntypedParameter, UntypedParameter> = "*", UntypedParameter, ",", KwargParameter<UntypedParameter>, "," => ActionFn(1346);
+                // ParameterList<UntypedParameter, UntypedParameter> = "*", UntypedParameter, ",", KwargParameter<UntypedParameter>, "," => ActionFn(1347);
                 assert!(__symbols.len() >= 5);
                 let __sym4 = __pop_Variant0(__symbols);
                 let __sym3 = __pop_Variant9(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
-                let __sym1 = __pop_Variant81(__symbols);
+                let __sym1 = __pop_Variant83(__symbols);
                 let __sym0 = __pop_Variant0(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym4.2;
-                let __nt = match super::__action1346::<>(__sym0, __sym1, __sym2, __sym3, __sym4) {
+                let __nt = match super::__action1347::<>(__sym0, __sym1, __sym2, __sym3, __sym4) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -15825,7 +15827,7 @@ mod __parse__Top {
                 (5, 201)
             }
             669 => {
-                // ParameterList<UntypedParameter, UntypedParameter> = "*", ",", KwargParameter<UntypedParameter>, "," => ActionFn(1347);
+                // ParameterList<UntypedParameter, UntypedParameter> = "*", ",", KwargParameter<UntypedParameter>, "," => ActionFn(1348);
                 assert!(__symbols.len() >= 4);
                 let __sym3 = __pop_Variant0(__symbols);
                 let __sym2 = __pop_Variant9(__symbols);
@@ -15833,7 +15835,7 @@ mod __parse__Top {
                 let __sym0 = __pop_Variant0(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym3.2;
-                let __nt = match super::__action1347::<>(__sym0, __sym1, __sym2, __sym3) {
+                let __nt = match super::__action1348::<>(__sym0, __sym1, __sym2, __sym3) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -15841,17 +15843,17 @@ mod __parse__Top {
                 (4, 201)
             }
             670 => {
-                // ParameterList<UntypedParameter, UntypedParameter> = "*", UntypedParameter, ("," <ParameterDef<UntypedParameter>>)+, ",", KwargParameter<UntypedParameter>, "," => ActionFn(1348);
+                // ParameterList<UntypedParameter, UntypedParameter> = "*", UntypedParameter, ("," <ParameterDef<UntypedParameter>>)+, ",", KwargParameter<UntypedParameter>, "," => ActionFn(1349);
                 assert!(__symbols.len() >= 6);
                 let __sym5 = __pop_Variant0(__symbols);
                 let __sym4 = __pop_Variant9(__symbols);
                 let __sym3 = __pop_Variant0(__symbols);
                 let __sym2 = __pop_Variant12(__symbols);
-                let __sym1 = __pop_Variant81(__symbols);
+                let __sym1 = __pop_Variant83(__symbols);
                 let __sym0 = __pop_Variant0(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym5.2;
-                let __nt = match super::__action1348::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5) {
+                let __nt = match super::__action1349::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -15859,7 +15861,7 @@ mod __parse__Top {
                 (6, 201)
             }
             671 => {
-                // ParameterList<UntypedParameter, UntypedParameter> = "*", ("," <ParameterDef<UntypedParameter>>)+, ",", KwargParameter<UntypedParameter>, "," => ActionFn(1349);
+                // ParameterList<UntypedParameter, UntypedParameter> = "*", ("," <ParameterDef<UntypedParameter>>)+, ",", KwargParameter<UntypedParameter>, "," => ActionFn(1350);
                 assert!(__symbols.len() >= 5);
                 let __sym4 = __pop_Variant0(__symbols);
                 let __sym3 = __pop_Variant9(__symbols);
@@ -15868,7 +15870,7 @@ mod __parse__Top {
                 let __sym0 = __pop_Variant0(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym4.2;
-                let __nt = match super::__action1349::<>(__sym0, __sym1, __sym2, __sym3, __sym4) {
+                let __nt = match super::__action1350::<>(__sym0, __sym1, __sym2, __sym3, __sym4) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -15876,14 +15878,14 @@ mod __parse__Top {
                 (5, 201)
             }
             672 => {
-                // ParameterList<UntypedParameter, UntypedParameter> = "*", UntypedParameter, "," => ActionFn(1350);
+                // ParameterList<UntypedParameter, UntypedParameter> = "*", UntypedParameter, "," => ActionFn(1351);
                 assert!(__symbols.len() >= 3);
                 let __sym2 = __pop_Variant0(__symbols);
-                let __sym1 = __pop_Variant81(__symbols);
+                let __sym1 = __pop_Variant83(__symbols);
                 let __sym0 = __pop_Variant0(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym2.2;
-                let __nt = match super::__action1350::<>(__sym0, __sym1, __sym2) {
+                let __nt = match super::__action1351::<>(__sym0, __sym1, __sym2) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -15891,13 +15893,13 @@ mod __parse__Top {
                 (3, 201)
             }
             673 => {
-                // ParameterList<UntypedParameter, UntypedParameter> = "*", "," => ActionFn(1351);
+                // ParameterList<UntypedParameter, UntypedParameter> = "*", "," => ActionFn(1352);
                 assert!(__symbols.len() >= 2);
                 let __sym1 = __pop_Variant0(__symbols);
                 let __sym0 = __pop_Variant0(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym1.2;
-                let __nt = match super::__action1351::<>(__sym0, __sym1) {
+                let __nt = match super::__action1352::<>(__sym0, __sym1) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -15905,15 +15907,15 @@ mod __parse__Top {
                 (2, 201)
             }
             674 => {
-                // ParameterList<UntypedParameter, UntypedParameter> = "*", UntypedParameter, ("," <ParameterDef<UntypedParameter>>)+, "," => ActionFn(1352);
+                // ParameterList<UntypedParameter, UntypedParameter> = "*", UntypedParameter, ("," <ParameterDef<UntypedParameter>>)+, "," => ActionFn(1353);
                 assert!(__symbols.len() >= 4);
                 let __sym3 = __pop_Variant0(__symbols);
                 let __sym2 = __pop_Variant12(__symbols);
-                let __sym1 = __pop_Variant81(__symbols);
+                let __sym1 = __pop_Variant83(__symbols);
                 let __sym0 = __pop_Variant0(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym3.2;
-                let __nt = match super::__action1352::<>(__sym0, __sym1, __sym2, __sym3) {
+                let __nt = match super::__action1353::<>(__sym0, __sym1, __sym2, __sym3) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -15921,14 +15923,14 @@ mod __parse__Top {
                 (4, 201)
             }
             675 => {
-                // ParameterList<UntypedParameter, UntypedParameter> = "*", ("," <ParameterDef<UntypedParameter>>)+, "," => ActionFn(1353);
+                // ParameterList<UntypedParameter, UntypedParameter> = "*", ("," <ParameterDef<UntypedParameter>>)+, "," => ActionFn(1354);
                 assert!(__symbols.len() >= 3);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant12(__symbols);
                 let __sym0 = __pop_Variant0(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym2.2;
-                let __nt = match super::__action1353::<>(__sym0, __sym1, __sym2) {
+                let __nt = match super::__action1354::<>(__sym0, __sym1, __sym2) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -15936,15 +15938,15 @@ mod __parse__Top {
                 (3, 201)
             }
             676 => {
-                // ParameterList<UntypedParameter, UntypedParameter> = "*", UntypedParameter, ",", KwargParameter<UntypedParameter> => ActionFn(1354);
+                // ParameterList<UntypedParameter, UntypedParameter> = "*", UntypedParameter, ",", KwargParameter<UntypedParameter> => ActionFn(1355);
                 assert!(__symbols.len() >= 4);
                 let __sym3 = __pop_Variant9(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
-                let __sym1 = __pop_Variant81(__symbols);
+                let __sym1 = __pop_Variant83(__symbols);
                 let __sym0 = __pop_Variant0(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym3.2;
-                let __nt = match super::__action1354::<>(__sym0, __sym1, __sym2, __sym3) {
+                let __nt = match super::__action1355::<>(__sym0, __sym1, __sym2, __sym3) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -15952,14 +15954,14 @@ mod __parse__Top {
                 (4, 201)
             }
             677 => {
-                // ParameterList<UntypedParameter, UntypedParameter> = "*", ",", KwargParameter<UntypedParameter> => ActionFn(1355);
+                // ParameterList<UntypedParameter, UntypedParameter> = "*", ",", KwargParameter<UntypedParameter> => ActionFn(1356);
                 assert!(__symbols.len() >= 3);
                 let __sym2 = __pop_Variant9(__symbols);
                 let __sym1 = __pop_Variant0(__symbols);
                 let __sym0 = __pop_Variant0(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym2.2;
-                let __nt = match super::__action1355::<>(__sym0, __sym1, __sym2) {
+                let __nt = match super::__action1356::<>(__sym0, __sym1, __sym2) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -15967,16 +15969,16 @@ mod __parse__Top {
                 (3, 201)
             }
             678 => {
-                // ParameterList<UntypedParameter, UntypedParameter> = "*", UntypedParameter, ("," <ParameterDef<UntypedParameter>>)+, ",", KwargParameter<UntypedParameter> => ActionFn(1356);
+                // ParameterList<UntypedParameter, UntypedParameter> = "*", UntypedParameter, ("," <ParameterDef<UntypedParameter>>)+, ",", KwargParameter<UntypedParameter> => ActionFn(1357);
                 assert!(__symbols.len() >= 5);
                 let __sym4 = __pop_Variant9(__symbols);
                 let __sym3 = __pop_Variant0(__symbols);
                 let __sym2 = __pop_Variant12(__symbols);
-                let __sym1 = __pop_Variant81(__symbols);
+                let __sym1 = __pop_Variant83(__symbols);
                 let __sym0 = __pop_Variant0(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym4.2;
-                let __nt = match super::__action1356::<>(__sym0, __sym1, __sym2, __sym3, __sym4) {
+                let __nt = match super::__action1357::<>(__sym0, __sym1, __sym2, __sym3, __sym4) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -15984,7 +15986,7 @@ mod __parse__Top {
                 (5, 201)
             }
             679 => {
-                // ParameterList<UntypedParameter, UntypedParameter> = "*", ("," <ParameterDef<UntypedParameter>>)+, ",", KwargParameter<UntypedParameter> => ActionFn(1357);
+                // ParameterList<UntypedParameter, UntypedParameter> = "*", ("," <ParameterDef<UntypedParameter>>)+, ",", KwargParameter<UntypedParameter> => ActionFn(1358);
                 assert!(__symbols.len() >= 4);
                 let __sym3 = __pop_Variant9(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
@@ -15992,7 +15994,7 @@ mod __parse__Top {
                 let __sym0 = __pop_Variant0(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym3.2;
-                let __nt = match super::__action1357::<>(__sym0, __sym1, __sym2, __sym3) {
+                let __nt = match super::__action1358::<>(__sym0, __sym1, __sym2, __sym3) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -16000,13 +16002,13 @@ mod __parse__Top {
                 (4, 201)
             }
             680 => {
-                // ParameterList<UntypedParameter, UntypedParameter> = "*", UntypedParameter => ActionFn(1358);
+                // ParameterList<UntypedParameter, UntypedParameter> = "*", UntypedParameter => ActionFn(1359);
                 assert!(__symbols.len() >= 2);
-                let __sym1 = __pop_Variant81(__symbols);
+                let __sym1 = __pop_Variant83(__symbols);
                 let __sym0 = __pop_Variant0(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym1.2;
-                let __nt = match super::__action1358::<>(__sym0, __sym1) {
+                let __nt = match super::__action1359::<>(__sym0, __sym1) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -16014,11 +16016,11 @@ mod __parse__Top {
                 (2, 201)
             }
             681 => {
-                // ParameterList<UntypedParameter, UntypedParameter> = "*" => ActionFn(1359);
+                // ParameterList<UntypedParameter, UntypedParameter> = "*" => ActionFn(1360);
                 let __sym0 = __pop_Variant0(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym0.2;
-                let __nt = match super::__action1359::<>(__sym0) {
+                let __nt = match super::__action1360::<>(__sym0) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -16026,14 +16028,14 @@ mod __parse__Top {
                 (1, 201)
             }
             682 => {
-                // ParameterList<UntypedParameter, UntypedParameter> = "*", UntypedParameter, ("," <ParameterDef<UntypedParameter>>)+ => ActionFn(1360);
+                // ParameterList<UntypedParameter, UntypedParameter> = "*", UntypedParameter, ("," <ParameterDef<UntypedParameter>>)+ => ActionFn(1361);
                 assert!(__symbols.len() >= 3);
                 let __sym2 = __pop_Variant12(__symbols);
-                let __sym1 = __pop_Variant81(__symbols);
+                let __sym1 = __pop_Variant83(__symbols);
                 let __sym0 = __pop_Variant0(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym2.2;
-                let __nt = match super::__action1360::<>(__sym0, __sym1, __sym2) {
+                let __nt = match super::__action1361::<>(__sym0, __sym1, __sym2) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -16041,13 +16043,13 @@ mod __parse__Top {
                 (3, 201)
             }
             683 => {
-                // ParameterList<UntypedParameter, UntypedParameter> = "*", ("," <ParameterDef<UntypedParameter>>)+ => ActionFn(1361);
+                // ParameterList<UntypedParameter, UntypedParameter> = "*", ("," <ParameterDef<UntypedParameter>>)+ => ActionFn(1362);
                 assert!(__symbols.len() >= 2);
                 let __sym1 = __pop_Variant12(__symbols);
                 let __sym0 = __pop_Variant0(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym1.2;
-                let __nt = match super::__action1361::<>(__sym0, __sym1) {
+                let __nt = match super::__action1362::<>(__sym0, __sym1) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -16071,7 +16073,7 @@ mod __parse__Top {
                 assert!(__symbols.len() >= 4);
                 let __sym3 = __pop_Variant9(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
-                let __sym1 = __pop_Variant81(__symbols);
+                let __sym1 = __pop_Variant83(__symbols);
                 let __sym0 = __pop_Variant0(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym3.2;
@@ -16103,7 +16105,7 @@ mod __parse__Top {
                 let __sym4 = __pop_Variant9(__symbols);
                 let __sym3 = __pop_Variant0(__symbols);
                 let __sym2 = __pop_Variant12(__symbols);
-                let __sym1 = __pop_Variant81(__symbols);
+                let __sym1 = __pop_Variant83(__symbols);
                 let __sym0 = __pop_Variant0(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym4.2;
@@ -16133,7 +16135,7 @@ mod __parse__Top {
             692 => {
                 // ParameterListStarArgs<TypedParameter, StarTypedParameter> = "*", StarTypedParameter => ActionFn(850);
                 assert!(__symbols.len() >= 2);
-                let __sym1 = __pop_Variant81(__symbols);
+                let __sym1 = __pop_Variant83(__symbols);
                 let __sym0 = __pop_Variant0(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym1.2;
@@ -16160,7 +16162,7 @@ mod __parse__Top {
                 // ParameterListStarArgs<TypedParameter, StarTypedParameter> = "*", StarTypedParameter, ("," <ParameterDef<TypedParameter>>)+ => ActionFn(852);
                 assert!(__symbols.len() >= 3);
                 let __sym2 = __pop_Variant12(__symbols);
-                let __sym1 = __pop_Variant81(__symbols);
+                let __sym1 = __pop_Variant83(__symbols);
                 let __sym0 = __pop_Variant0(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym2.2;
@@ -16190,7 +16192,7 @@ mod __parse__Top {
                 assert!(__symbols.len() >= 4);
                 let __sym3 = __pop_Variant9(__symbols);
                 let __sym2 = __pop_Variant0(__symbols);
-                let __sym1 = __pop_Variant81(__symbols);
+                let __sym1 = __pop_Variant83(__symbols);
                 let __sym0 = __pop_Variant0(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym3.2;
@@ -16222,7 +16224,7 @@ mod __parse__Top {
                 let __sym4 = __pop_Variant9(__symbols);
                 let __sym3 = __pop_Variant0(__symbols);
                 let __sym2 = __pop_Variant12(__symbols);
-                let __sym1 = __pop_Variant81(__symbols);
+                let __sym1 = __pop_Variant83(__symbols);
                 let __sym0 = __pop_Variant0(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym4.2;
@@ -16252,7 +16254,7 @@ mod __parse__Top {
             700 => {
                 // ParameterListStarArgs<UntypedParameter, UntypedParameter> = "*", UntypedParameter => ActionFn(968);
                 assert!(__symbols.len() >= 2);
-                let __sym1 = __pop_Variant81(__symbols);
+                let __sym1 = __pop_Variant83(__symbols);
                 let __sym0 = __pop_Variant0(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym1.2;
@@ -16279,7 +16281,7 @@ mod __parse__Top {
                 // ParameterListStarArgs<UntypedParameter, UntypedParameter> = "*", UntypedParameter, ("," <ParameterDef<UntypedParameter>>)+ => ActionFn(970);
                 assert!(__symbols.len() >= 3);
                 let __sym2 = __pop_Variant12(__symbols);
-                let __sym1 = __pop_Variant81(__symbols);
+                let __sym1 = __pop_Variant83(__symbols);
                 let __sym0 = __pop_Variant0(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym2.2;
@@ -16305,14 +16307,14 @@ mod __parse__Top {
                 (2, 204)
             }
             704 => {
-                // Parameters = "(", ParameterList<TypedParameter, StarTypedParameter>, ")" => ActionFn(1443);
+                // Parameters = "(", ParameterList<TypedParameter, StarTypedParameter>, ")" => ActionFn(1444);
                 assert!(__symbols.len() >= 3);
                 let __sym2 = __pop_Variant0(__symbols);
                 let __sym1 = __pop_Variant44(__symbols);
                 let __sym0 = __pop_Variant0(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym2.2;
-                let __nt = match super::__action1443::<>(__sym0, __sym1, __sym2) {
+                let __nt = match super::__action1444::<>(__sym0, __sym1, __sym2) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -16320,13 +16322,13 @@ mod __parse__Top {
                 (3, 205)
             }
             705 => {
-                // Parameters = "(", ")" => ActionFn(1444);
+                // Parameters = "(", ")" => ActionFn(1445);
                 assert!(__symbols.len() >= 2);
                 let __sym1 = __pop_Variant0(__symbols);
                 let __sym0 = __pop_Variant0(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym1.2;
-                let __nt = match super::__action1444::<>(__sym0, __sym1) {
+                let __nt = match super::__action1445::<>(__sym0, __sym1) {
                     Ok(v) => v,
                     Err(e) => return Some(Err(e)),
                 };
@@ -16860,7 +16862,7 @@ mod __parse__Top {
             }
             881 => {
                 // __Top = Top => ActionFn(0);
-                let __sym0 = __pop_Variant84(__symbols);
+                let __sym0 = __pop_Variant86(__symbols);
                 let __start = __sym0.0;
                 let __end = __sym0.2;
                 let __nt = super::__action0::<>(__sym0);
@@ -16899,23 +16901,23 @@ mod __parse__Top {
             _ => __symbol_type_mismatch()
         }
     }
-    fn __pop_Variant55<
+    fn __pop_Variant57<
     >(
         __symbols: &mut alloc::vec::Vec<(TextSize,__Symbol<>,TextSize)>
     ) -> (TextSize, (Option<Box<ast::Expr>>, ast::Expr), TextSize)
      {
         match __symbols.pop() {
-            Some((__l, __Symbol::Variant55(__v), __r)) => (__l, __v, __r),
+            Some((__l, __Symbol::Variant57(__v), __r)) => (__l, __v, __r),
             _ => __symbol_type_mismatch()
         }
     }
-    fn __pop_Variant66<
+    fn __pop_Variant68<
     >(
         __symbols: &mut alloc::vec::Vec<(TextSize,__Symbol<>,TextSize)>
     ) -> (TextSize, (Option<ast::Int>, Option<ast::Identifier>), TextSize)
      {
         match __symbols.pop() {
-            Some((__l, __Symbol::Variant66(__v), __r)) => (__l, __v, __r),
+            Some((__l, __Symbol::Variant68(__v), __r)) => (__l, __v, __r),
             _ => __symbol_type_mismatch()
         }
     }
@@ -16949,13 +16951,13 @@ mod __parse__Top {
             _ => __symbol_type_mismatch()
         }
     }
-    fn __pop_Variant75<
+    fn __pop_Variant77<
     >(
         __symbols: &mut alloc::vec::Vec<(TextSize,__Symbol<>,TextSize)>
     ) -> (TextSize, (Vec<(ast::Arg, Option<ast::Expr>)>, Vec<(ast::Arg, Option<ast::Expr>)>), TextSize)
      {
         match __symbols.pop() {
-            Some((__l, __Symbol::Variant75(__v), __r)) => (__l, __v, __r),
+            Some((__l, __Symbol::Variant77(__v), __r)) => (__l, __v, __r),
             _ => __symbol_type_mismatch()
         }
     }
@@ -16979,13 +16981,13 @@ mod __parse__Top {
             _ => __symbol_type_mismatch()
         }
     }
-    fn __pop_Variant56<
+    fn __pop_Variant58<
     >(
         __symbols: &mut alloc::vec::Vec<(TextSize,__Symbol<>,TextSize)>
     ) -> (TextSize, (ast::Expr, ast::Expr), TextSize)
      {
         match __symbols.pop() {
-            Some((__l, __Symbol::Variant56(__v), __r)) => (__l, __v, __r),
+            Some((__l, __Symbol::Variant58(__v), __r)) => (__l, __v, __r),
             _ => __symbol_type_mismatch()
         }
     }
@@ -16999,23 +17001,23 @@ mod __parse__Top {
             _ => __symbol_type_mismatch()
         }
     }
-    fn __pop_Variant70<
+    fn __pop_Variant72<
     >(
         __symbols: &mut alloc::vec::Vec<(TextSize,__Symbol<>,TextSize)>
     ) -> (TextSize, (ast::Expr, ast::Pattern), TextSize)
      {
         match __symbols.pop() {
-            Some((__l, __Symbol::Variant70(__v), __r)) => (__l, __v, __r),
+            Some((__l, __Symbol::Variant72(__v), __r)) => (__l, __v, __r),
             _ => __symbol_type_mismatch()
         }
     }
-    fn __pop_Variant69<
+    fn __pop_Variant71<
     >(
         __symbols: &mut alloc::vec::Vec<(TextSize,__Symbol<>,TextSize)>
     ) -> (TextSize, (ast::Identifier, ast::Pattern), TextSize)
      {
         match __symbols.pop() {
-            Some((__l, __Symbol::Variant69(__v), __r)) => (__l, __v, __r),
+            Some((__l, __Symbol::Variant71(__v), __r)) => (__l, __v, __r),
             _ => __symbol_type_mismatch()
         }
     }
@@ -17079,13 +17081,13 @@ mod __parse__Top {
             _ => __symbol_type_mismatch()
         }
     }
-    fn __pop_Variant79<
+    fn __pop_Variant81<
     >(
         __symbols: &mut alloc::vec::Vec<(TextSize,__Symbol<>,TextSize)>
     ) -> (TextSize, Option<ast::Expr>, TextSize)
      {
         match __symbols.pop() {
-            Some((__l, __Symbol::Variant79(__v), __r)) => (__l, __v, __r),
+            Some((__l, __Symbol::Variant81(__v), __r)) => (__l, __v, __r),
             _ => __symbol_type_mismatch()
         }
     }
@@ -17119,53 +17121,53 @@ mod __parse__Top {
             _ => __symbol_type_mismatch()
         }
     }
-    fn __pop_Variant57<
+    fn __pop_Variant59<
     >(
         __symbols: &mut alloc::vec::Vec<(TextSize,__Symbol<>,TextSize)>
     ) -> (TextSize, Vec<(Option<Box<ast::Expr>>, ast::Expr)>, TextSize)
      {
         match __symbols.pop() {
-            Some((__l, __Symbol::Variant57(__v), __r)) => (__l, __v, __r),
+            Some((__l, __Symbol::Variant59(__v), __r)) => (__l, __v, __r),
+            _ => __symbol_type_mismatch()
+        }
+    }
+    fn __pop_Variant76<
+    >(
+        __symbols: &mut alloc::vec::Vec<(TextSize,__Symbol<>,TextSize)>
+    ) -> (TextSize, Vec<(ast::Arg, Option<ast::Expr>)>, TextSize)
+     {
+        match __symbols.pop() {
+            Some((__l, __Symbol::Variant76(__v), __r)) => (__l, __v, __r),
+            _ => __symbol_type_mismatch()
+        }
+    }
+    fn __pop_Variant75<
+    >(
+        __symbols: &mut alloc::vec::Vec<(TextSize,__Symbol<>,TextSize)>
+    ) -> (TextSize, Vec<(ast::Expr, ast::Pattern)>, TextSize)
+     {
+        match __symbols.pop() {
+            Some((__l, __Symbol::Variant75(__v), __r)) => (__l, __v, __r),
             _ => __symbol_type_mismatch()
         }
     }
     fn __pop_Variant74<
     >(
         __symbols: &mut alloc::vec::Vec<(TextSize,__Symbol<>,TextSize)>
-    ) -> (TextSize, Vec<(ast::Arg, Option<ast::Expr>)>, TextSize)
+    ) -> (TextSize, Vec<(ast::Identifier, ast::Pattern)>, TextSize)
      {
         match __symbols.pop() {
             Some((__l, __Symbol::Variant74(__v), __r)) => (__l, __v, __r),
             _ => __symbol_type_mismatch()
         }
     }
-    fn __pop_Variant73<
-    >(
-        __symbols: &mut alloc::vec::Vec<(TextSize,__Symbol<>,TextSize)>
-    ) -> (TextSize, Vec<(ast::Expr, ast::Pattern)>, TextSize)
-     {
-        match __symbols.pop() {
-            Some((__l, __Symbol::Variant73(__v), __r)) => (__l, __v, __r),
-            _ => __symbol_type_mismatch()
-        }
-    }
-    fn __pop_Variant72<
-    >(
-        __symbols: &mut alloc::vec::Vec<(TextSize,__Symbol<>,TextSize)>
-    ) -> (TextSize, Vec<(ast::Identifier, ast::Pattern)>, TextSize)
-     {
-        match __symbols.pop() {
-            Some((__l, __Symbol::Variant72(__v), __r)) => (__l, __v, __r),
-            _ => __symbol_type_mismatch()
-        }
-    }
-    fn __pop_Variant63<
+    fn __pop_Variant65<
     >(
         __symbols: &mut alloc::vec::Vec<(TextSize,__Symbol<>,TextSize)>
     ) -> (TextSize, Vec<ast::Alias>, TextSize)
      {
         match __symbols.pop() {
-            Some((__l, __Symbol::Variant63(__v), __r)) => (__l, __v, __r),
+            Some((__l, __Symbol::Variant65(__v), __r)) => (__l, __v, __r),
             _ => __symbol_type_mismatch()
         }
     }
@@ -17189,13 +17191,13 @@ mod __parse__Top {
             _ => __symbol_type_mismatch()
         }
     }
-    fn __pop_Variant71<
+    fn __pop_Variant73<
     >(
         __symbols: &mut alloc::vec::Vec<(TextSize,__Symbol<>,TextSize)>
     ) -> (TextSize, Vec<ast::Identifier>, TextSize)
      {
         match __symbols.pop() {
-            Some((__l, __Symbol::Variant71(__v), __r)) => (__l, __v, __r),
+            Some((__l, __Symbol::Variant73(__v), __r)) => (__l, __v, __r),
             _ => __symbol_type_mismatch()
         }
     }
@@ -17209,13 +17211,13 @@ mod __parse__Top {
             _ => __symbol_type_mismatch()
         }
     }
-    fn __pop_Variant83<
+    fn __pop_Variant85<
     >(
         __symbols: &mut alloc::vec::Vec<(TextSize,__Symbol<>,TextSize)>
     ) -> (TextSize, Vec<ast::Stmt>, TextSize)
      {
         match __symbols.pop() {
-            Some((__l, __Symbol::Variant83(__v), __r)) => (__l, __v, __r),
+            Some((__l, __Symbol::Variant85(__v), __r)) => (__l, __v, __r),
             _ => __symbol_type_mismatch()
         }
     }
@@ -17289,23 +17291,33 @@ mod __parse__Top {
             _ => __symbol_type_mismatch()
         }
     }
-    fn __pop_Variant78<
+    fn __pop_Variant80<
     >(
         __symbols: &mut alloc::vec::Vec<(TextSize,__Symbol<>,TextSize)>
     ) -> (TextSize, alloc::vec::Vec<ast::Comprehension>, TextSize)
      {
         match __symbols.pop() {
-            Some((__l, __Symbol::Variant78(__v), __r)) => (__l, __v, __r),
+            Some((__l, __Symbol::Variant80(__v), __r)) => (__l, __v, __r),
             _ => __symbol_type_mismatch()
         }
     }
-    fn __pop_Variant60<
+    fn __pop_Variant56<
+    >(
+        __symbols: &mut alloc::vec::Vec<(TextSize,__Symbol<>,TextSize)>
+    ) -> (TextSize, alloc::vec::Vec<ast::Decorator>, TextSize)
+     {
+        match __symbols.pop() {
+            Some((__l, __Symbol::Variant56(__v), __r)) => (__l, __v, __r),
+            _ => __symbol_type_mismatch()
+        }
+    }
+    fn __pop_Variant62<
     >(
         __symbols: &mut alloc::vec::Vec<(TextSize,__Symbol<>,TextSize)>
     ) -> (TextSize, alloc::vec::Vec<ast::Excepthandler>, TextSize)
      {
         match __symbols.pop() {
-            Some((__l, __Symbol::Variant60(__v), __r)) => (__l, __v, __r),
+            Some((__l, __Symbol::Variant62(__v), __r)) => (__l, __v, __r),
             _ => __symbol_type_mismatch()
         }
     }
@@ -17319,23 +17331,23 @@ mod __parse__Top {
             _ => __symbol_type_mismatch()
         }
     }
-    fn __pop_Variant65<
+    fn __pop_Variant67<
     >(
         __symbols: &mut alloc::vec::Vec<(TextSize,__Symbol<>,TextSize)>
     ) -> (TextSize, alloc::vec::Vec<ast::Int>, TextSize)
      {
         match __symbols.pop() {
-            Some((__l, __Symbol::Variant65(__v), __r)) => (__l, __v, __r),
+            Some((__l, __Symbol::Variant67(__v), __r)) => (__l, __v, __r),
             _ => __symbol_type_mismatch()
         }
     }
-    fn __pop_Variant68<
+    fn __pop_Variant70<
     >(
         __symbols: &mut alloc::vec::Vec<(TextSize,__Symbol<>,TextSize)>
     ) -> (TextSize, alloc::vec::Vec<ast::MatchCase>, TextSize)
      {
         match __symbols.pop() {
-            Some((__l, __Symbol::Variant68(__v), __r)) => (__l, __v, __r),
+            Some((__l, __Symbol::Variant70(__v), __r)) => (__l, __v, __r),
             _ => __symbol_type_mismatch()
         }
     }
@@ -17379,23 +17391,23 @@ mod __parse__Top {
             _ => __symbol_type_mismatch()
         }
     }
-    fn __pop_Variant62<
+    fn __pop_Variant64<
     >(
         __symbols: &mut alloc::vec::Vec<(TextSize,__Symbol<>,TextSize)>
     ) -> (TextSize, ast::Alias, TextSize)
      {
         match __symbols.pop() {
-            Some((__l, __Symbol::Variant62(__v), __r)) => (__l, __v, __r),
+            Some((__l, __Symbol::Variant64(__v), __r)) => (__l, __v, __r),
             _ => __symbol_type_mismatch()
         }
     }
-    fn __pop_Variant81<
+    fn __pop_Variant83<
     >(
         __symbols: &mut alloc::vec::Vec<(TextSize,__Symbol<>,TextSize)>
     ) -> (TextSize, ast::Arg, TextSize)
      {
         match __symbols.pop() {
-            Some((__l, __Symbol::Variant81(__v), __r)) => (__l, __v, __r),
+            Some((__l, __Symbol::Variant83(__v), __r)) => (__l, __v, __r),
             _ => __symbol_type_mismatch()
         }
     }
@@ -17419,13 +17431,13 @@ mod __parse__Top {
             _ => __symbol_type_mismatch()
         }
     }
-    fn __pop_Variant77<
+    fn __pop_Variant79<
     >(
         __symbols: &mut alloc::vec::Vec<(TextSize,__Symbol<>,TextSize)>
     ) -> (TextSize, ast::Comprehension, TextSize)
      {
         match __symbols.pop() {
-            Some((__l, __Symbol::Variant77(__v), __r)) => (__l, __v, __r),
+            Some((__l, __Symbol::Variant79(__v), __r)) => (__l, __v, __r),
             _ => __symbol_type_mismatch()
         }
     }
@@ -17439,13 +17451,23 @@ mod __parse__Top {
             _ => __symbol_type_mismatch()
         }
     }
-    fn __pop_Variant59<
+    fn __pop_Variant55<
+    >(
+        __symbols: &mut alloc::vec::Vec<(TextSize,__Symbol<>,TextSize)>
+    ) -> (TextSize, ast::Decorator, TextSize)
+     {
+        match __symbols.pop() {
+            Some((__l, __Symbol::Variant55(__v), __r)) => (__l, __v, __r),
+            _ => __symbol_type_mismatch()
+        }
+    }
+    fn __pop_Variant61<
     >(
         __symbols: &mut alloc::vec::Vec<(TextSize,__Symbol<>,TextSize)>
     ) -> (TextSize, ast::Excepthandler, TextSize)
      {
         match __symbols.pop() {
-            Some((__l, __Symbol::Variant59(__v), __r)) => (__l, __v, __r),
+            Some((__l, __Symbol::Variant61(__v), __r)) => (__l, __v, __r),
             _ => __symbol_type_mismatch()
         }
     }
@@ -17469,33 +17491,33 @@ mod __parse__Top {
             _ => __symbol_type_mismatch()
         }
     }
-    fn __pop_Variant64<
+    fn __pop_Variant66<
     >(
         __symbols: &mut alloc::vec::Vec<(TextSize,__Symbol<>,TextSize)>
     ) -> (TextSize, ast::Int, TextSize)
      {
         match __symbols.pop() {
-            Some((__l, __Symbol::Variant64(__v), __r)) => (__l, __v, __r),
+            Some((__l, __Symbol::Variant66(__v), __r)) => (__l, __v, __r),
             _ => __symbol_type_mismatch()
         }
     }
-    fn __pop_Variant67<
+    fn __pop_Variant69<
     >(
         __symbols: &mut alloc::vec::Vec<(TextSize,__Symbol<>,TextSize)>
     ) -> (TextSize, ast::MatchCase, TextSize)
      {
         match __symbols.pop() {
-            Some((__l, __Symbol::Variant67(__v), __r)) => (__l, __v, __r),
+            Some((__l, __Symbol::Variant69(__v), __r)) => (__l, __v, __r),
             _ => __symbol_type_mismatch()
         }
     }
-    fn __pop_Variant84<
+    fn __pop_Variant86<
     >(
         __symbols: &mut alloc::vec::Vec<(TextSize,__Symbol<>,TextSize)>
     ) -> (TextSize, ast::Mod, TextSize)
      {
         match __symbols.pop() {
-            Some((__l, __Symbol::Variant84(__v), __r)) => (__l, __v, __r),
+            Some((__l, __Symbol::Variant86(__v), __r)) => (__l, __v, __r),
             _ => __symbol_type_mismatch()
         }
     }
@@ -17539,13 +17561,13 @@ mod __parse__Top {
             _ => __symbol_type_mismatch()
         }
     }
-    fn __pop_Variant85<
+    fn __pop_Variant87<
     >(
         __symbols: &mut alloc::vec::Vec<(TextSize,__Symbol<>,TextSize)>
     ) -> (TextSize, ast::Unaryop, TextSize)
      {
         match __symbols.pop() {
-            Some((__l, __Symbol::Variant85(__v), __r)) => (__l, __v, __r),
+            Some((__l, __Symbol::Variant87(__v), __r)) => (__l, __v, __r),
             _ => __symbol_type_mismatch()
         }
     }
@@ -17559,13 +17581,13 @@ mod __parse__Top {
             _ => __symbol_type_mismatch()
         }
     }
-    fn __pop_Variant61<
+    fn __pop_Variant63<
     >(
         __symbols: &mut alloc::vec::Vec<(TextSize,__Symbol<>,TextSize)>
     ) -> (TextSize, core::option::Option<(Option<(TextSize, TextSize, Option<ast::Identifier>)>, ast::Expr)>, TextSize)
      {
         match __symbols.pop() {
-            Some((__l, __Symbol::Variant61(__v), __r)) => (__l, __v, __r),
+            Some((__l, __Symbol::Variant63(__v), __r)) => (__l, __v, __r),
             _ => __symbol_type_mismatch()
         }
     }
@@ -17599,23 +17621,23 @@ mod __parse__Top {
             _ => __symbol_type_mismatch()
         }
     }
-    fn __pop_Variant80<
+    fn __pop_Variant82<
     >(
         __symbols: &mut alloc::vec::Vec<(TextSize,__Symbol<>,TextSize)>
     ) -> (TextSize, core::option::Option<Option<ast::Expr>>, TextSize)
      {
         match __symbols.pop() {
-            Some((__l, __Symbol::Variant80(__v), __r)) => (__l, __v, __r),
+            Some((__l, __Symbol::Variant82(__v), __r)) => (__l, __v, __r),
             _ => __symbol_type_mismatch()
         }
     }
-    fn __pop_Variant58<
+    fn __pop_Variant60<
     >(
         __symbols: &mut alloc::vec::Vec<(TextSize,__Symbol<>,TextSize)>
     ) -> (TextSize, core::option::Option<Vec<(Option<Box<ast::Expr>>, ast::Expr)>>, TextSize)
      {
         match __symbols.pop() {
-            Some((__l, __Symbol::Variant58(__v), __r)) => (__l, __v, __r),
+            Some((__l, __Symbol::Variant60(__v), __r)) => (__l, __v, __r),
             _ => __symbol_type_mismatch()
         }
     }
@@ -17649,13 +17671,13 @@ mod __parse__Top {
             _ => __symbol_type_mismatch()
         }
     }
-    fn __pop_Variant82<
+    fn __pop_Variant84<
     >(
         __symbols: &mut alloc::vec::Vec<(TextSize,__Symbol<>,TextSize)>
     ) -> (TextSize, core::option::Option<ast::Arg>, TextSize)
      {
         match __symbols.pop() {
-            Some((__l, __Symbol::Variant82(__v), __r)) => (__l, __v, __r),
+            Some((__l, __Symbol::Variant84(__v), __r)) => (__l, __v, __r),
             _ => __symbol_type_mismatch()
         }
     }
@@ -17689,13 +17711,13 @@ mod __parse__Top {
             _ => __symbol_type_mismatch()
         }
     }
-    fn __pop_Variant76<
+    fn __pop_Variant78<
     >(
         __symbols: &mut alloc::vec::Vec<(TextSize,__Symbol<>,TextSize)>
     ) -> (TextSize, core::option::Option<ast::Pattern>, TextSize)
      {
         match __symbols.pop() {
-            Some((__l, __Symbol::Variant76(__v), __r)) => (__l, __v, __r),
+            Some((__l, __Symbol::Variant78(__v), __r)) => (__l, __v, __r),
             _ => __symbol_type_mismatch()
         }
     }
@@ -19347,13 +19369,13 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // (<WithItemsNoAs> ",") = OneOrMore<Test<"all">>, "," => ActionFn(1423);
+        // (<WithItemsNoAs> ",") = OneOrMore<Test<"all">>, "," => ActionFn(1424);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant31(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action1423::<>(__sym0, __sym1);
+        let __nt = super::__action1424::<>(__sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant38(__nt), __end));
         (2, 65)
     }
@@ -19364,13 +19386,13 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // (<WithItemsNoAs> ",")? = OneOrMore<Test<"all">>, "," => ActionFn(1426);
+        // (<WithItemsNoAs> ",")? = OneOrMore<Test<"all">>, "," => ActionFn(1427);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant31(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action1426::<>(__sym0, __sym1);
+        let __nt = super::__action1427::<>(__sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant39(__nt), __end));
         (2, 66)
     }
@@ -19410,11 +19432,11 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // (@L string @R)+ = string => ActionFn(1435);
+        // (@L string @R)+ = string => ActionFn(1436);
         let __sym0 = __pop_Variant5(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action1435::<>(__sym0);
+        let __nt = super::__action1436::<>(__sym0);
         __symbols.push((__start, __Symbol::Variant41(__nt), __end));
         (1, 68)
     }
@@ -19425,13 +19447,13 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // (@L string @R)+ = (@L string @R)+, string => ActionFn(1436);
+        // (@L string @R)+ = (@L string @R)+, string => ActionFn(1437);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant5(__symbols);
         let __sym0 = __pop_Variant41(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action1436::<>(__sym0, __sym1);
+        let __nt = super::__action1437::<>(__sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant41(__nt), __end));
         (2, 68)
     }
@@ -19459,13 +19481,13 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // (CompOp Expression<"all">)+ = CompOp, Expression<"all"> => ActionFn(1437);
+        // (CompOp Expression<"all">)+ = CompOp, Expression<"all"> => ActionFn(1438);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant15(__symbols);
         let __sym0 = __pop_Variant53(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action1437::<>(__sym0, __sym1);
+        let __nt = super::__action1438::<>(__sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant43(__nt), __end));
         (2, 70)
     }
@@ -19476,14 +19498,14 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // (CompOp Expression<"all">)+ = (CompOp Expression<"all">)+, CompOp, Expression<"all"> => ActionFn(1438);
+        // (CompOp Expression<"all">)+ = (CompOp Expression<"all">)+, CompOp, Expression<"all"> => ActionFn(1439);
         assert!(__symbols.len() >= 3);
         let __sym2 = __pop_Variant15(__symbols);
         let __sym1 = __pop_Variant53(__symbols);
         let __sym0 = __pop_Variant43(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
-        let __nt = super::__action1438::<>(__sym0, __sym1, __sym2);
+        let __nt = super::__action1439::<>(__sym0, __sym1, __sym2);
         __symbols.push((__start, __Symbol::Variant43(__nt), __end));
         (3, 70)
     }
@@ -19509,11 +19531,11 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // (Guard)? = Guard => ActionFn(1439);
+        // (Guard)? = Guard => ActionFn(1440);
         let __sym0 = __pop_Variant15(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action1439::<>(__sym0);
+        let __nt = super::__action1440::<>(__sym0);
         __symbols.push((__start, __Symbol::Variant16(__nt), __end));
         (1, 72)
     }
@@ -19553,11 +19575,11 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // (ParameterList<TypedParameter, StarTypedParameter>)? = ParameterList<TypedParameter, StarTypedParameter> => ActionFn(1442);
+        // (ParameterList<TypedParameter, StarTypedParameter>)? = ParameterList<TypedParameter, StarTypedParameter> => ActionFn(1443);
         let __sym0 = __pop_Variant44(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action1442::<>(__sym0);
+        let __nt = super::__action1443::<>(__sym0);
         __symbols.push((__start, __Symbol::Variant45(__nt), __end));
         (1, 74)
     }
@@ -20027,14 +20049,14 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // Atom<"all"> = "[", ListLiteralValues, "]" => ActionFn(1497);
+        // Atom<"all"> = "[", ListLiteralValues, "]" => ActionFn(1498);
         assert!(__symbols.len() >= 3);
         let __sym2 = __pop_Variant0(__symbols);
         let __sym1 = __pop_Variant31(__symbols);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
-        let __nt = super::__action1497::<>(__sym0, __sym1, __sym2);
+        let __nt = super::__action1498::<>(__sym0, __sym1, __sym2);
         __symbols.push((__start, __Symbol::Variant15(__nt), __end));
         (3, 92)
     }
@@ -20045,13 +20067,13 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // Atom<"all"> = "[", "]" => ActionFn(1498);
+        // Atom<"all"> = "[", "]" => ActionFn(1499);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action1498::<>(__sym0, __sym1);
+        let __nt = super::__action1499::<>(__sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant15(__nt), __end));
         (2, 92)
     }
@@ -20172,14 +20194,14 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // Atom<"all"> = "{", DictLiteralValues, "}" => ActionFn(1483);
+        // Atom<"all"> = "{", DictLiteralValues, "}" => ActionFn(1484);
         assert!(__symbols.len() >= 3);
         let __sym2 = __pop_Variant0(__symbols);
-        let __sym1 = __pop_Variant57(__symbols);
+        let __sym1 = __pop_Variant59(__symbols);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
-        let __nt = super::__action1483::<>(__sym0, __sym1, __sym2);
+        let __nt = super::__action1484::<>(__sym0, __sym1, __sym2);
         __symbols.push((__start, __Symbol::Variant15(__nt), __end));
         (3, 92)
     }
@@ -20190,13 +20212,13 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // Atom<"all"> = "{", "}" => ActionFn(1484);
+        // Atom<"all"> = "{", "}" => ActionFn(1485);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action1484::<>(__sym0, __sym1);
+        let __nt = super::__action1485::<>(__sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant15(__nt), __end));
         (2, 92)
     }
@@ -20211,7 +20233,7 @@ mod __parse__Top {
         assert!(__symbols.len() >= 4);
         let __sym3 = __pop_Variant0(__symbols);
         let __sym2 = __pop_Variant51(__symbols);
-        let __sym1 = __pop_Variant56(__symbols);
+        let __sym1 = __pop_Variant58(__symbols);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym3.2;
@@ -20353,14 +20375,14 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // Atom<"no-withitems"> = "[", ListLiteralValues, "]" => ActionFn(1499);
+        // Atom<"no-withitems"> = "[", ListLiteralValues, "]" => ActionFn(1500);
         assert!(__symbols.len() >= 3);
         let __sym2 = __pop_Variant0(__symbols);
         let __sym1 = __pop_Variant31(__symbols);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
-        let __nt = super::__action1499::<>(__sym0, __sym1, __sym2);
+        let __nt = super::__action1500::<>(__sym0, __sym1, __sym2);
         __symbols.push((__start, __Symbol::Variant15(__nt), __end));
         (3, 93)
     }
@@ -20371,13 +20393,13 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // Atom<"no-withitems"> = "[", "]" => ActionFn(1500);
+        // Atom<"no-withitems"> = "[", "]" => ActionFn(1501);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action1500::<>(__sym0, __sym1);
+        let __nt = super::__action1501::<>(__sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant15(__nt), __end));
         (2, 93)
     }
@@ -20461,14 +20483,14 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // Atom<"no-withitems"> = "{", DictLiteralValues, "}" => ActionFn(1485);
+        // Atom<"no-withitems"> = "{", DictLiteralValues, "}" => ActionFn(1486);
         assert!(__symbols.len() >= 3);
         let __sym2 = __pop_Variant0(__symbols);
-        let __sym1 = __pop_Variant57(__symbols);
+        let __sym1 = __pop_Variant59(__symbols);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
-        let __nt = super::__action1485::<>(__sym0, __sym1, __sym2);
+        let __nt = super::__action1486::<>(__sym0, __sym1, __sym2);
         __symbols.push((__start, __Symbol::Variant15(__nt), __end));
         (3, 93)
     }
@@ -20479,13 +20501,13 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // Atom<"no-withitems"> = "{", "}" => ActionFn(1486);
+        // Atom<"no-withitems"> = "{", "}" => ActionFn(1487);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action1486::<>(__sym0, __sym1);
+        let __nt = super::__action1487::<>(__sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant15(__nt), __end));
         (2, 93)
     }
@@ -20500,7 +20522,7 @@ mod __parse__Top {
         assert!(__symbols.len() >= 4);
         let __sym3 = __pop_Variant0(__symbols);
         let __sym2 = __pop_Variant51(__symbols);
-        let __sym1 = __pop_Variant56(__symbols);
+        let __sym1 = __pop_Variant58(__symbols);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym3.2;
@@ -21028,7 +21050,7 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // ClassDef = "class", Identifier, "(", ArgumentList, ")", ":", Suite => ActionFn(1471);
+        // ClassDef = "class", Identifier, "(", ArgumentList, ")", ":", Suite => ActionFn(1472);
         assert!(__symbols.len() >= 7);
         let __sym6 = __pop_Variant25(__symbols);
         let __sym5 = __pop_Variant0(__symbols);
@@ -21039,7 +21061,7 @@ mod __parse__Top {
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym6.2;
-        let __nt = super::__action1471::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6);
+        let __nt = super::__action1472::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6);
         __symbols.push((__start, __Symbol::Variant35(__nt), __end));
         (7, 100)
     }
@@ -21050,7 +21072,7 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // ClassDef = Decorator+, "class", Identifier, "(", ArgumentList, ")", ":", Suite => ActionFn(1472);
+        // ClassDef = Decorator+, "class", Identifier, "(", ArgumentList, ")", ":", Suite => ActionFn(1473);
         assert!(__symbols.len() >= 8);
         let __sym7 = __pop_Variant25(__symbols);
         let __sym6 = __pop_Variant0(__symbols);
@@ -21059,10 +21081,10 @@ mod __parse__Top {
         let __sym3 = __pop_Variant0(__symbols);
         let __sym2 = __pop_Variant23(__symbols);
         let __sym1 = __pop_Variant0(__symbols);
-        let __sym0 = __pop_Variant17(__symbols);
+        let __sym0 = __pop_Variant56(__symbols);
         let __start = __sym0.0;
         let __end = __sym7.2;
-        let __nt = super::__action1472::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7);
+        let __nt = super::__action1473::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7);
         __symbols.push((__start, __Symbol::Variant35(__nt), __end));
         (8, 100)
     }
@@ -21073,7 +21095,7 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // ClassDef = "class", Identifier, ":", Suite => ActionFn(1473);
+        // ClassDef = "class", Identifier, ":", Suite => ActionFn(1474);
         assert!(__symbols.len() >= 4);
         let __sym3 = __pop_Variant25(__symbols);
         let __sym2 = __pop_Variant0(__symbols);
@@ -21081,7 +21103,7 @@ mod __parse__Top {
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym3.2;
-        let __nt = super::__action1473::<>(__sym0, __sym1, __sym2, __sym3);
+        let __nt = super::__action1474::<>(__sym0, __sym1, __sym2, __sym3);
         __symbols.push((__start, __Symbol::Variant35(__nt), __end));
         (4, 100)
     }
@@ -21092,16 +21114,16 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // ClassDef = Decorator+, "class", Identifier, ":", Suite => ActionFn(1474);
+        // ClassDef = Decorator+, "class", Identifier, ":", Suite => ActionFn(1475);
         assert!(__symbols.len() >= 5);
         let __sym4 = __pop_Variant25(__symbols);
         let __sym3 = __pop_Variant0(__symbols);
         let __sym2 = __pop_Variant23(__symbols);
         let __sym1 = __pop_Variant0(__symbols);
-        let __sym0 = __pop_Variant17(__symbols);
+        let __sym0 = __pop_Variant56(__symbols);
         let __start = __sym0.0;
         let __end = __sym4.2;
-        let __nt = super::__action1474::<>(__sym0, __sym1, __sym2, __sym3, __sym4);
+        let __nt = super::__action1475::<>(__sym0, __sym1, __sym2, __sym3, __sym4);
         __symbols.push((__start, __Symbol::Variant35(__nt), __end));
         (5, 100)
     }
@@ -21116,7 +21138,7 @@ mod __parse__Top {
         assert!(__symbols.len() >= 7);
         let __sym6 = __pop_Variant0(__symbols);
         let __sym5 = __pop_Variant0(__symbols);
-        let __sym4 = __pop_Variant72(__symbols);
+        let __sym4 = __pop_Variant74(__symbols);
         let __sym3 = __pop_Variant0(__symbols);
         let __sym2 = __pop_Variant50(__symbols);
         let __sym1 = __pop_Variant0(__symbols);
@@ -21137,7 +21159,7 @@ mod __parse__Top {
         // ClassPattern = MatchName, "(", OneOrMore<Pattern>, ",", OneOrMore<MatchKeywordEntry>, ")" => ActionFn(1213);
         assert!(__symbols.len() >= 6);
         let __sym5 = __pop_Variant0(__symbols);
-        let __sym4 = __pop_Variant72(__symbols);
+        let __sym4 = __pop_Variant74(__symbols);
         let __sym3 = __pop_Variant0(__symbols);
         let __sym2 = __pop_Variant50(__symbols);
         let __sym1 = __pop_Variant0(__symbols);
@@ -21198,7 +21220,7 @@ mod __parse__Top {
         assert!(__symbols.len() >= 5);
         let __sym4 = __pop_Variant0(__symbols);
         let __sym3 = __pop_Variant0(__symbols);
-        let __sym2 = __pop_Variant72(__symbols);
+        let __sym2 = __pop_Variant74(__symbols);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant15(__symbols);
         let __start = __sym0.0;
@@ -21217,7 +21239,7 @@ mod __parse__Top {
         // ClassPattern = MatchName, "(", OneOrMore<MatchKeywordEntry>, ")" => ActionFn(1217);
         assert!(__symbols.len() >= 4);
         let __sym3 = __pop_Variant0(__symbols);
-        let __sym2 = __pop_Variant72(__symbols);
+        let __sym2 = __pop_Variant74(__symbols);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant15(__symbols);
         let __start = __sym0.0;
@@ -21255,7 +21277,7 @@ mod __parse__Top {
         assert!(__symbols.len() >= 7);
         let __sym6 = __pop_Variant0(__symbols);
         let __sym5 = __pop_Variant0(__symbols);
-        let __sym4 = __pop_Variant72(__symbols);
+        let __sym4 = __pop_Variant74(__symbols);
         let __sym3 = __pop_Variant0(__symbols);
         let __sym2 = __pop_Variant50(__symbols);
         let __sym1 = __pop_Variant0(__symbols);
@@ -21276,7 +21298,7 @@ mod __parse__Top {
         // ClassPattern = MatchNameOrAttr, "(", OneOrMore<Pattern>, ",", OneOrMore<MatchKeywordEntry>, ")" => ActionFn(1220);
         assert!(__symbols.len() >= 6);
         let __sym5 = __pop_Variant0(__symbols);
-        let __sym4 = __pop_Variant72(__symbols);
+        let __sym4 = __pop_Variant74(__symbols);
         let __sym3 = __pop_Variant0(__symbols);
         let __sym2 = __pop_Variant50(__symbols);
         let __sym1 = __pop_Variant0(__symbols);
@@ -21337,7 +21359,7 @@ mod __parse__Top {
         assert!(__symbols.len() >= 5);
         let __sym4 = __pop_Variant0(__symbols);
         let __sym3 = __pop_Variant0(__symbols);
-        let __sym2 = __pop_Variant72(__symbols);
+        let __sym2 = __pop_Variant74(__symbols);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant15(__symbols);
         let __start = __sym0.0;
@@ -21356,7 +21378,7 @@ mod __parse__Top {
         // ClassPattern = MatchNameOrAttr, "(", OneOrMore<MatchKeywordEntry>, ")" => ActionFn(1224);
         assert!(__symbols.len() >= 4);
         let __sym3 = __pop_Variant0(__symbols);
-        let __sym2 = __pop_Variant72(__symbols);
+        let __sym2 = __pop_Variant74(__symbols);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant15(__symbols);
         let __start = __sym0.0;
@@ -21495,11 +21517,11 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // Comma<FunctionArgument> = FunctionArgument => ActionFn(1449);
+        // Comma<FunctionArgument> = FunctionArgument => ActionFn(1450);
         let __sym0 = __pop_Variant29(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action1449::<>(__sym0);
+        let __nt = super::__action1450::<>(__sym0);
         __symbols.push((__start, __Symbol::Variant49(__nt), __end));
         (1, 103)
     }
@@ -21510,10 +21532,10 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // Comma<FunctionArgument> =  => ActionFn(1450);
+        // Comma<FunctionArgument> =  => ActionFn(1451);
         let __start = __lookahead_start.cloned().or_else(|| __symbols.last().map(|s| s.2.clone())).unwrap_or_default();
         let __end = __start.clone();
-        let __nt = super::__action1450::<>(&__start, &__end);
+        let __nt = super::__action1451::<>(&__start, &__end);
         __symbols.push((__start, __Symbol::Variant49(__nt), __end));
         (0, 103)
     }
@@ -21524,13 +21546,13 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // Comma<FunctionArgument> = (<FunctionArgument> ",")+, FunctionArgument => ActionFn(1451);
+        // Comma<FunctionArgument> = (<FunctionArgument> ",")+, FunctionArgument => ActionFn(1452);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant29(__symbols);
         let __sym0 = __pop_Variant30(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action1451::<>(__sym0, __sym1);
+        let __nt = super::__action1452::<>(__sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant49(__nt), __end));
         (2, 103)
     }
@@ -21541,11 +21563,11 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // Comma<FunctionArgument> = (<FunctionArgument> ",")+ => ActionFn(1452);
+        // Comma<FunctionArgument> = (<FunctionArgument> ",")+ => ActionFn(1453);
         let __sym0 = __pop_Variant30(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action1452::<>(__sym0);
+        let __nt = super::__action1453::<>(__sym0);
         __symbols.push((__start, __Symbol::Variant49(__nt), __end));
         (1, 103)
     }
@@ -21556,11 +21578,11 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // Comma<Pattern> = Pattern => ActionFn(1457);
+        // Comma<Pattern> = Pattern => ActionFn(1458);
         let __sym0 = __pop_Variant33(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action1457::<>(__sym0);
+        let __nt = super::__action1458::<>(__sym0);
         __symbols.push((__start, __Symbol::Variant50(__nt), __end));
         (1, 104)
     }
@@ -21571,10 +21593,10 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // Comma<Pattern> =  => ActionFn(1458);
+        // Comma<Pattern> =  => ActionFn(1459);
         let __start = __lookahead_start.cloned().or_else(|| __symbols.last().map(|s| s.2.clone())).unwrap_or_default();
         let __end = __start.clone();
-        let __nt = super::__action1458::<>(&__start, &__end);
+        let __nt = super::__action1459::<>(&__start, &__end);
         __symbols.push((__start, __Symbol::Variant50(__nt), __end));
         (0, 104)
     }
@@ -21585,13 +21607,13 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // Comma<Pattern> = (<Pattern> ",")+, Pattern => ActionFn(1459);
+        // Comma<Pattern> = (<Pattern> ",")+, Pattern => ActionFn(1460);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant33(__symbols);
         let __sym0 = __pop_Variant34(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action1459::<>(__sym0, __sym1);
+        let __nt = super::__action1460::<>(__sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant50(__nt), __end));
         (2, 104)
     }
@@ -21602,11 +21624,11 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // Comma<Pattern> = (<Pattern> ",")+ => ActionFn(1460);
+        // Comma<Pattern> = (<Pattern> ",")+ => ActionFn(1461);
         let __sym0 = __pop_Variant34(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action1460::<>(__sym0);
+        let __nt = super::__action1461::<>(__sym0);
         __symbols.push((__start, __Symbol::Variant50(__nt), __end));
         (1, 104)
     }
@@ -21618,7 +21640,7 @@ mod __parse__Top {
     ) -> (usize, usize)
     {
         // CompFor = SingleForComprehension+ => ActionFn(210);
-        let __sym0 = __pop_Variant78(__symbols);
+        let __sym0 = __pop_Variant80(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
         let __nt = super::__action210::<>(__sym0);
@@ -22169,15 +22191,15 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // Decorator = "@", NamedExpressionTest, "\n" => ActionFn(758);
+        // Decorator = "@", NamedExpressionTest, "\n" => ActionFn(1230);
         assert!(__symbols.len() >= 3);
         let __sym2 = __pop_Variant0(__symbols);
         let __sym1 = __pop_Variant15(__symbols);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
-        let __nt = super::__action758::<>(__sym0, __sym1, __sym2);
-        __symbols.push((__start, __Symbol::Variant15(__nt), __end));
+        let __nt = super::__action1230::<>(__sym0, __sym1, __sym2);
+        __symbols.push((__start, __Symbol::Variant55(__nt), __end));
         (3, 117)
     }
     pub(crate) fn __reduce329<
@@ -22191,7 +22213,7 @@ mod __parse__Top {
         let __start = __lookahead_start.cloned().or_else(|| __symbols.last().map(|s| s.2.clone())).unwrap_or_default();
         let __end = __start.clone();
         let __nt = super::__action271::<>(&__start, &__end);
-        __symbols.push((__start, __Symbol::Variant17(__nt), __end));
+        __symbols.push((__start, __Symbol::Variant56(__nt), __end));
         (0, 118)
     }
     pub(crate) fn __reduce330<
@@ -22202,11 +22224,11 @@ mod __parse__Top {
     ) -> (usize, usize)
     {
         // Decorator* = Decorator+ => ActionFn(272);
-        let __sym0 = __pop_Variant17(__symbols);
+        let __sym0 = __pop_Variant56(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
         let __nt = super::__action272::<>(__sym0);
-        __symbols.push((__start, __Symbol::Variant17(__nt), __end));
+        __symbols.push((__start, __Symbol::Variant56(__nt), __end));
         (1, 118)
     }
     pub(crate) fn __reduce331<
@@ -22217,11 +22239,11 @@ mod __parse__Top {
     ) -> (usize, usize)
     {
         // Decorator+ = Decorator => ActionFn(390);
-        let __sym0 = __pop_Variant15(__symbols);
+        let __sym0 = __pop_Variant55(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
         let __nt = super::__action390::<>(__sym0);
-        __symbols.push((__start, __Symbol::Variant17(__nt), __end));
+        __symbols.push((__start, __Symbol::Variant56(__nt), __end));
         (1, 119)
     }
     pub(crate) fn __reduce332<
@@ -22233,12 +22255,12 @@ mod __parse__Top {
     {
         // Decorator+ = Decorator+, Decorator => ActionFn(391);
         assert!(__symbols.len() >= 2);
-        let __sym1 = __pop_Variant15(__symbols);
-        let __sym0 = __pop_Variant17(__symbols);
+        let __sym1 = __pop_Variant55(__symbols);
+        let __sym0 = __pop_Variant56(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
         let __nt = super::__action391::<>(__sym0, __sym1);
-        __symbols.push((__start, __Symbol::Variant17(__nt), __end));
+        __symbols.push((__start, __Symbol::Variant56(__nt), __end));
         (2, 119)
     }
     pub(crate) fn __reduce333<
@@ -22248,13 +22270,13 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // DelStatement = "del", ExpressionList2 => ActionFn(1230);
+        // DelStatement = "del", ExpressionList2 => ActionFn(1231);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant31(__symbols);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action1230::<>(__sym0, __sym1);
+        let __nt = super::__action1231::<>(__sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant35(__nt), __end));
         (2, 120)
     }
@@ -22266,11 +22288,11 @@ mod __parse__Top {
     ) -> (usize, usize)
     {
         // DictElement = DictEntry => ActionFn(201);
-        let __sym0 = __pop_Variant56(__symbols);
+        let __sym0 = __pop_Variant58(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
         let __nt = super::__action201::<>(__sym0);
-        __symbols.push((__start, __Symbol::Variant55(__nt), __end));
+        __symbols.push((__start, __Symbol::Variant57(__nt), __end));
         (1, 121)
     }
     pub(crate) fn __reduce335<
@@ -22287,7 +22309,7 @@ mod __parse__Top {
         let __start = __sym0.0;
         let __end = __sym1.2;
         let __nt = super::__action202::<>(__sym0, __sym1);
-        __symbols.push((__start, __Symbol::Variant55(__nt), __end));
+        __symbols.push((__start, __Symbol::Variant57(__nt), __end));
         (2, 121)
     }
     pub(crate) fn __reduce336<
@@ -22305,7 +22327,7 @@ mod __parse__Top {
         let __start = __sym0.0;
         let __end = __sym2.2;
         let __nt = super::__action200::<>(__sym0, __sym1, __sym2);
-        __symbols.push((__start, __Symbol::Variant56(__nt), __end));
+        __symbols.push((__start, __Symbol::Variant58(__nt), __end));
         (3, 122)
     }
     pub(crate) fn __reduce337<
@@ -22318,11 +22340,11 @@ mod __parse__Top {
         // DictLiteralValues = OneOrMore<DictElement>, "," => ActionFn(579);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant0(__symbols);
-        let __sym0 = __pop_Variant57(__symbols);
+        let __sym0 = __pop_Variant59(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
         let __nt = super::__action579::<>(__sym0, __sym1);
-        __symbols.push((__start, __Symbol::Variant57(__nt), __end));
+        __symbols.push((__start, __Symbol::Variant59(__nt), __end));
         (2, 123)
     }
     pub(crate) fn __reduce338<
@@ -22333,11 +22355,11 @@ mod __parse__Top {
     ) -> (usize, usize)
     {
         // DictLiteralValues = OneOrMore<DictElement> => ActionFn(580);
-        let __sym0 = __pop_Variant57(__symbols);
+        let __sym0 = __pop_Variant59(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
         let __nt = super::__action580::<>(__sym0);
-        __symbols.push((__start, __Symbol::Variant57(__nt), __end));
+        __symbols.push((__start, __Symbol::Variant59(__nt), __end));
         (1, 123)
     }
     pub(crate) fn __reduce339<
@@ -22348,11 +22370,11 @@ mod __parse__Top {
     ) -> (usize, usize)
     {
         // DictLiteralValues? = DictLiteralValues => ActionFn(521);
-        let __sym0 = __pop_Variant57(__symbols);
+        let __sym0 = __pop_Variant59(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
         let __nt = super::__action521::<>(__sym0);
-        __symbols.push((__start, __Symbol::Variant58(__nt), __end));
+        __symbols.push((__start, __Symbol::Variant60(__nt), __end));
         (1, 124)
     }
     pub(crate) fn __reduce340<
@@ -22366,7 +22388,7 @@ mod __parse__Top {
         let __start = __lookahead_start.cloned().or_else(|| __symbols.last().map(|s| s.2.clone())).unwrap_or_default();
         let __end = __start.clone();
         let __nt = super::__action522::<>(&__start, &__end);
-        __symbols.push((__start, __Symbol::Variant58(__nt), __end));
+        __symbols.push((__start, __Symbol::Variant60(__nt), __end));
         (0, 124)
     }
     pub(crate) fn __reduce341<
@@ -22408,7 +22430,7 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // ExceptClause = "except", Test<"all">, ":", Suite => ActionFn(1625);
+        // ExceptClause = "except", Test<"all">, ":", Suite => ActionFn(1626);
         assert!(__symbols.len() >= 4);
         let __sym3 = __pop_Variant25(__symbols);
         let __sym2 = __pop_Variant0(__symbols);
@@ -22416,8 +22438,8 @@ mod __parse__Top {
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym3.2;
-        let __nt = super::__action1625::<>(__sym0, __sym1, __sym2, __sym3);
-        __symbols.push((__start, __Symbol::Variant59(__nt), __end));
+        let __nt = super::__action1626::<>(__sym0, __sym1, __sym2, __sym3);
+        __symbols.push((__start, __Symbol::Variant61(__nt), __end));
         (4, 126)
     }
     pub(crate) fn __reduce344<
@@ -22427,15 +22449,15 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // ExceptClause = "except", ":", Suite => ActionFn(1626);
+        // ExceptClause = "except", ":", Suite => ActionFn(1627);
         assert!(__symbols.len() >= 3);
         let __sym2 = __pop_Variant25(__symbols);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
-        let __nt = super::__action1626::<>(__sym0, __sym1, __sym2);
-        __symbols.push((__start, __Symbol::Variant59(__nt), __end));
+        let __nt = super::__action1627::<>(__sym0, __sym1, __sym2);
+        __symbols.push((__start, __Symbol::Variant61(__nt), __end));
         (3, 126)
     }
     pub(crate) fn __reduce345<
@@ -22456,7 +22478,7 @@ mod __parse__Top {
         let __start = __sym0.0;
         let __end = __sym5.2;
         let __nt = super::__action1142::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5);
-        __symbols.push((__start, __Symbol::Variant59(__nt), __end));
+        __symbols.push((__start, __Symbol::Variant61(__nt), __end));
         (6, 126)
     }
     pub(crate) fn __reduce346<
@@ -22467,11 +22489,11 @@ mod __parse__Top {
     ) -> (usize, usize)
     {
         // ExceptClause+ = ExceptClause => ActionFn(296);
-        let __sym0 = __pop_Variant59(__symbols);
+        let __sym0 = __pop_Variant61(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
         let __nt = super::__action296::<>(__sym0);
-        __symbols.push((__start, __Symbol::Variant60(__nt), __end));
+        __symbols.push((__start, __Symbol::Variant62(__nt), __end));
         (1, 127)
     }
     pub(crate) fn __reduce347<
@@ -22483,12 +22505,12 @@ mod __parse__Top {
     {
         // ExceptClause+ = ExceptClause+, ExceptClause => ActionFn(297);
         assert!(__symbols.len() >= 2);
-        let __sym1 = __pop_Variant59(__symbols);
-        let __sym0 = __pop_Variant60(__symbols);
+        let __sym1 = __pop_Variant61(__symbols);
+        let __sym0 = __pop_Variant62(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
         let __nt = super::__action297::<>(__sym0, __sym1);
-        __symbols.push((__start, __Symbol::Variant60(__nt), __end));
+        __symbols.push((__start, __Symbol::Variant62(__nt), __end));
         (2, 127)
     }
     pub(crate) fn __reduce348<
@@ -22508,7 +22530,7 @@ mod __parse__Top {
         let __start = __sym0.0;
         let __end = __sym4.2;
         let __nt = super::__action762::<>(__sym0, __sym1, __sym2, __sym3, __sym4);
-        __symbols.push((__start, __Symbol::Variant59(__nt), __end));
+        __symbols.push((__start, __Symbol::Variant61(__nt), __end));
         (5, 128)
     }
     pub(crate) fn __reduce349<
@@ -22530,7 +22552,7 @@ mod __parse__Top {
         let __start = __sym0.0;
         let __end = __sym6.2;
         let __nt = super::__action1143::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6);
-        __symbols.push((__start, __Symbol::Variant59(__nt), __end));
+        __symbols.push((__start, __Symbol::Variant61(__nt), __end));
         (7, 128)
     }
     pub(crate) fn __reduce350<
@@ -22541,11 +22563,11 @@ mod __parse__Top {
     ) -> (usize, usize)
     {
         // ExceptStarClause+ = ExceptStarClause => ActionFn(291);
-        let __sym0 = __pop_Variant59(__symbols);
+        let __sym0 = __pop_Variant61(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
         let __nt = super::__action291::<>(__sym0);
-        __symbols.push((__start, __Symbol::Variant60(__nt), __end));
+        __symbols.push((__start, __Symbol::Variant62(__nt), __end));
         (1, 129)
     }
     pub(crate) fn __reduce351<
@@ -22557,12 +22579,12 @@ mod __parse__Top {
     {
         // ExceptStarClause+ = ExceptStarClause+, ExceptStarClause => ActionFn(292);
         assert!(__symbols.len() >= 2);
-        let __sym1 = __pop_Variant59(__symbols);
-        let __sym0 = __pop_Variant60(__symbols);
+        let __sym1 = __pop_Variant61(__symbols);
+        let __sym0 = __pop_Variant62(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
         let __nt = super::__action292::<>(__sym0, __sym1);
-        __symbols.push((__start, __Symbol::Variant60(__nt), __end));
+        __symbols.push((__start, __Symbol::Variant62(__nt), __end));
         (2, 129)
     }
     pub(crate) fn __reduce352<
@@ -22572,14 +22594,14 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // Expression<"all"> = Expression<"all">, "|", XorExpression<"all"> => ActionFn(1231);
+        // Expression<"all"> = Expression<"all">, "|", XorExpression<"all"> => ActionFn(1232);
         assert!(__symbols.len() >= 3);
         let __sym2 = __pop_Variant15(__symbols);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant15(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
-        let __nt = super::__action1231::<>(__sym0, __sym1, __sym2);
+        let __nt = super::__action1232::<>(__sym0, __sym1, __sym2);
         __symbols.push((__start, __Symbol::Variant15(__nt), __end));
         (3, 130)
     }
@@ -22605,14 +22627,14 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // Expression<"no-withitems"> = Expression<"all">, "|", XorExpression<"all"> => ActionFn(1232);
+        // Expression<"no-withitems"> = Expression<"all">, "|", XorExpression<"all"> => ActionFn(1233);
         assert!(__symbols.len() >= 3);
         let __sym2 = __pop_Variant15(__symbols);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant15(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
-        let __nt = super::__action1232::<>(__sym0, __sym1, __sym2);
+        let __nt = super::__action1233::<>(__sym0, __sym1, __sym2);
         __symbols.push((__start, __Symbol::Variant15(__nt), __end));
         (3, 131)
     }
@@ -22730,11 +22752,11 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // ExpressionStatement = GenericList<TestOrStarExpr> => ActionFn(1650);
+        // ExpressionStatement = GenericList<TestOrStarExpr> => ActionFn(1651);
         let __sym0 = __pop_Variant15(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action1650::<>(__sym0);
+        let __nt = super::__action1651::<>(__sym0);
         __symbols.push((__start, __Symbol::Variant35(__nt), __end));
         (1, 136)
     }
@@ -22745,13 +22767,13 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // ExpressionStatement = GenericList<TestOrStarExpr>, AssignSuffix+ => ActionFn(1651);
+        // ExpressionStatement = GenericList<TestOrStarExpr>, AssignSuffix+ => ActionFn(1652);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant17(__symbols);
         let __sym0 = __pop_Variant15(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action1651::<>(__sym0, __sym1);
+        let __nt = super::__action1652::<>(__sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant35(__nt), __end));
         (2, 136)
     }
@@ -22762,14 +22784,14 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // ExpressionStatement = GenericList<TestOrStarExpr>, AugAssign, TestListOrYieldExpr => ActionFn(1652);
+        // ExpressionStatement = GenericList<TestOrStarExpr>, AugAssign, TestListOrYieldExpr => ActionFn(1653);
         assert!(__symbols.len() >= 3);
         let __sym2 = __pop_Variant15(__symbols);
         let __sym1 = __pop_Variant47(__symbols);
         let __sym0 = __pop_Variant15(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
-        let __nt = super::__action1652::<>(__sym0, __sym1, __sym2);
+        let __nt = super::__action1653::<>(__sym0, __sym1, __sym2);
         __symbols.push((__start, __Symbol::Variant35(__nt), __end));
         (3, 136)
     }
@@ -22780,7 +22802,7 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // ExpressionStatement = Test<"all">, ":", Test<"all">, AssignSuffix => ActionFn(1447);
+        // ExpressionStatement = Test<"all">, ":", Test<"all">, AssignSuffix => ActionFn(1448);
         assert!(__symbols.len() >= 4);
         let __sym3 = __pop_Variant15(__symbols);
         let __sym2 = __pop_Variant15(__symbols);
@@ -22788,7 +22810,7 @@ mod __parse__Top {
         let __sym0 = __pop_Variant15(__symbols);
         let __start = __sym0.0;
         let __end = __sym3.2;
-        let __nt = super::__action1447::<>(__sym0, __sym1, __sym2, __sym3);
+        let __nt = super::__action1448::<>(__sym0, __sym1, __sym2, __sym3);
         __symbols.push((__start, __Symbol::Variant35(__nt), __end));
         (4, 136)
     }
@@ -22799,14 +22821,14 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // ExpressionStatement = Test<"all">, ":", Test<"all"> => ActionFn(1448);
+        // ExpressionStatement = Test<"all">, ":", Test<"all"> => ActionFn(1449);
         assert!(__symbols.len() >= 3);
         let __sym2 = __pop_Variant15(__symbols);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant15(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
-        let __nt = super::__action1448::<>(__sym0, __sym1, __sym2);
+        let __nt = super::__action1449::<>(__sym0, __sym1, __sym2);
         __symbols.push((__start, __Symbol::Variant35(__nt), __end));
         (3, 136)
     }
@@ -22817,13 +22839,13 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // Factor<"all"> = UnaryOp, Factor<"all"> => ActionFn(1236);
+        // Factor<"all"> = UnaryOp, Factor<"all"> => ActionFn(1237);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant15(__symbols);
-        let __sym0 = __pop_Variant85(__symbols);
+        let __sym0 = __pop_Variant87(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action1236::<>(__sym0, __sym1);
+        let __nt = super::__action1237::<>(__sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant15(__nt), __end));
         (2, 137)
     }
@@ -22849,13 +22871,13 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // Factor<"no-withitems"> = UnaryOp, Factor<"all"> => ActionFn(1237);
+        // Factor<"no-withitems"> = UnaryOp, Factor<"all"> => ActionFn(1238);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant15(__symbols);
-        let __sym0 = __pop_Variant85(__symbols);
+        let __sym0 = __pop_Variant87(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action1237::<>(__sym0, __sym1);
+        let __nt = super::__action1238::<>(__sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant15(__nt), __end));
         (2, 138)
     }
@@ -22881,11 +22903,11 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // FlowStatement = "break" => ActionFn(1238);
+        // FlowStatement = "break" => ActionFn(1239);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action1238::<>(__sym0);
+        let __nt = super::__action1239::<>(__sym0);
         __symbols.push((__start, __Symbol::Variant35(__nt), __end));
         (1, 139)
     }
@@ -22896,11 +22918,11 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // FlowStatement = "continue" => ActionFn(1239);
+        // FlowStatement = "continue" => ActionFn(1240);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action1239::<>(__sym0);
+        let __nt = super::__action1240::<>(__sym0);
         __symbols.push((__start, __Symbol::Variant35(__nt), __end));
         (1, 139)
     }
@@ -22911,13 +22933,13 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // FlowStatement = "return", GenericList<TestOrStarExpr> => ActionFn(1646);
+        // FlowStatement = "return", GenericList<TestOrStarExpr> => ActionFn(1647);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant15(__symbols);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action1646::<>(__sym0, __sym1);
+        let __nt = super::__action1647::<>(__sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant35(__nt), __end));
         (2, 139)
     }
@@ -22928,11 +22950,11 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // FlowStatement = "return" => ActionFn(1647);
+        // FlowStatement = "return" => ActionFn(1648);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action1647::<>(__sym0);
+        let __nt = super::__action1648::<>(__sym0);
         __symbols.push((__start, __Symbol::Variant35(__nt), __end));
         (1, 139)
     }
@@ -22943,11 +22965,11 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // FlowStatement = YieldExpr => ActionFn(1241);
+        // FlowStatement = YieldExpr => ActionFn(1242);
         let __sym0 = __pop_Variant15(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action1241::<>(__sym0);
+        let __nt = super::__action1242::<>(__sym0);
         __symbols.push((__start, __Symbol::Variant35(__nt), __end));
         (1, 139)
     }
@@ -22973,7 +22995,7 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // ForStatement = "async", "for", ExpressionList, "in", GenericList<TestOrStarExpr>, ":", Suite, "else", ":", Suite => ActionFn(1637);
+        // ForStatement = "async", "for", ExpressionList, "in", GenericList<TestOrStarExpr>, ":", Suite, "else", ":", Suite => ActionFn(1638);
         assert!(__symbols.len() >= 10);
         let __sym9 = __pop_Variant25(__symbols);
         let __sym8 = __pop_Variant0(__symbols);
@@ -22987,7 +23009,7 @@ mod __parse__Top {
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym9.2;
-        let __nt = super::__action1637::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7, __sym8, __sym9);
+        let __nt = super::__action1638::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7, __sym8, __sym9);
         __symbols.push((__start, __Symbol::Variant35(__nt), __end));
         (10, 140)
     }
@@ -22998,7 +23020,7 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // ForStatement = "async", "for", ExpressionList, "in", GenericList<TestOrStarExpr>, ":", Suite => ActionFn(1638);
+        // ForStatement = "async", "for", ExpressionList, "in", GenericList<TestOrStarExpr>, ":", Suite => ActionFn(1639);
         assert!(__symbols.len() >= 7);
         let __sym6 = __pop_Variant25(__symbols);
         let __sym5 = __pop_Variant0(__symbols);
@@ -23009,7 +23031,7 @@ mod __parse__Top {
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym6.2;
-        let __nt = super::__action1638::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6);
+        let __nt = super::__action1639::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6);
         __symbols.push((__start, __Symbol::Variant35(__nt), __end));
         (7, 140)
     }
@@ -23020,7 +23042,7 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // ForStatement = "for", ExpressionList, "in", GenericList<TestOrStarExpr>, ":", Suite, "else", ":", Suite => ActionFn(1639);
+        // ForStatement = "for", ExpressionList, "in", GenericList<TestOrStarExpr>, ":", Suite, "else", ":", Suite => ActionFn(1640);
         assert!(__symbols.len() >= 9);
         let __sym8 = __pop_Variant25(__symbols);
         let __sym7 = __pop_Variant0(__symbols);
@@ -23033,7 +23055,7 @@ mod __parse__Top {
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym8.2;
-        let __nt = super::__action1639::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7, __sym8);
+        let __nt = super::__action1640::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7, __sym8);
         __symbols.push((__start, __Symbol::Variant35(__nt), __end));
         (9, 140)
     }
@@ -23044,7 +23066,7 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // ForStatement = "for", ExpressionList, "in", GenericList<TestOrStarExpr>, ":", Suite => ActionFn(1640);
+        // ForStatement = "for", ExpressionList, "in", GenericList<TestOrStarExpr>, ":", Suite => ActionFn(1641);
         assert!(__symbols.len() >= 6);
         let __sym5 = __pop_Variant25(__symbols);
         let __sym4 = __pop_Variant0(__symbols);
@@ -23054,7 +23076,7 @@ mod __parse__Top {
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym5.2;
-        let __nt = super::__action1640::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5);
+        let __nt = super::__action1641::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5);
         __symbols.push((__start, __Symbol::Variant35(__nt), __end));
         (6, 140)
     }
@@ -23065,7 +23087,7 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // FuncDef = "async", "def", Identifier, Parameters, "->", Test<"all">, ":", Suite => ActionFn(1475);
+        // FuncDef = "async", "def", Identifier, Parameters, "->", Test<"all">, ":", Suite => ActionFn(1476);
         assert!(__symbols.len() >= 8);
         let __sym7 = __pop_Variant25(__symbols);
         let __sym6 = __pop_Variant0(__symbols);
@@ -23077,7 +23099,7 @@ mod __parse__Top {
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym7.2;
-        let __nt = super::__action1475::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7);
+        let __nt = super::__action1476::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7);
         __symbols.push((__start, __Symbol::Variant35(__nt), __end));
         (8, 141)
     }
@@ -23088,7 +23110,7 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // FuncDef = Decorator+, "async", "def", Identifier, Parameters, "->", Test<"all">, ":", Suite => ActionFn(1476);
+        // FuncDef = Decorator+, "async", "def", Identifier, Parameters, "->", Test<"all">, ":", Suite => ActionFn(1477);
         assert!(__symbols.len() >= 9);
         let __sym8 = __pop_Variant25(__symbols);
         let __sym7 = __pop_Variant0(__symbols);
@@ -23098,10 +23120,10 @@ mod __parse__Top {
         let __sym3 = __pop_Variant23(__symbols);
         let __sym2 = __pop_Variant0(__symbols);
         let __sym1 = __pop_Variant0(__symbols);
-        let __sym0 = __pop_Variant17(__symbols);
+        let __sym0 = __pop_Variant56(__symbols);
         let __start = __sym0.0;
         let __end = __sym8.2;
-        let __nt = super::__action1476::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7, __sym8);
+        let __nt = super::__action1477::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7, __sym8);
         __symbols.push((__start, __Symbol::Variant35(__nt), __end));
         (9, 141)
     }
@@ -23112,7 +23134,7 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // FuncDef = "async", "def", Identifier, Parameters, ":", Suite => ActionFn(1477);
+        // FuncDef = "async", "def", Identifier, Parameters, ":", Suite => ActionFn(1478);
         assert!(__symbols.len() >= 6);
         let __sym5 = __pop_Variant25(__symbols);
         let __sym4 = __pop_Variant0(__symbols);
@@ -23122,7 +23144,7 @@ mod __parse__Top {
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym5.2;
-        let __nt = super::__action1477::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5);
+        let __nt = super::__action1478::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5);
         __symbols.push((__start, __Symbol::Variant35(__nt), __end));
         (6, 141)
     }
@@ -23133,7 +23155,7 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // FuncDef = Decorator+, "async", "def", Identifier, Parameters, ":", Suite => ActionFn(1478);
+        // FuncDef = Decorator+, "async", "def", Identifier, Parameters, ":", Suite => ActionFn(1479);
         assert!(__symbols.len() >= 7);
         let __sym6 = __pop_Variant25(__symbols);
         let __sym5 = __pop_Variant0(__symbols);
@@ -23141,10 +23163,10 @@ mod __parse__Top {
         let __sym3 = __pop_Variant23(__symbols);
         let __sym2 = __pop_Variant0(__symbols);
         let __sym1 = __pop_Variant0(__symbols);
-        let __sym0 = __pop_Variant17(__symbols);
+        let __sym0 = __pop_Variant56(__symbols);
         let __start = __sym0.0;
         let __end = __sym6.2;
-        let __nt = super::__action1478::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6);
+        let __nt = super::__action1479::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6);
         __symbols.push((__start, __Symbol::Variant35(__nt), __end));
         (7, 141)
     }
@@ -23155,7 +23177,7 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // FuncDef = "def", Identifier, Parameters, "->", Test<"all">, ":", Suite => ActionFn(1479);
+        // FuncDef = "def", Identifier, Parameters, "->", Test<"all">, ":", Suite => ActionFn(1480);
         assert!(__symbols.len() >= 7);
         let __sym6 = __pop_Variant25(__symbols);
         let __sym5 = __pop_Variant0(__symbols);
@@ -23166,7 +23188,7 @@ mod __parse__Top {
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym6.2;
-        let __nt = super::__action1479::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6);
+        let __nt = super::__action1480::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6);
         __symbols.push((__start, __Symbol::Variant35(__nt), __end));
         (7, 141)
     }
@@ -23177,7 +23199,7 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // FuncDef = Decorator+, "def", Identifier, Parameters, "->", Test<"all">, ":", Suite => ActionFn(1480);
+        // FuncDef = Decorator+, "def", Identifier, Parameters, "->", Test<"all">, ":", Suite => ActionFn(1481);
         assert!(__symbols.len() >= 8);
         let __sym7 = __pop_Variant25(__symbols);
         let __sym6 = __pop_Variant0(__symbols);
@@ -23186,10 +23208,10 @@ mod __parse__Top {
         let __sym3 = __pop_Variant44(__symbols);
         let __sym2 = __pop_Variant23(__symbols);
         let __sym1 = __pop_Variant0(__symbols);
-        let __sym0 = __pop_Variant17(__symbols);
+        let __sym0 = __pop_Variant56(__symbols);
         let __start = __sym0.0;
         let __end = __sym7.2;
-        let __nt = super::__action1480::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7);
+        let __nt = super::__action1481::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7);
         __symbols.push((__start, __Symbol::Variant35(__nt), __end));
         (8, 141)
     }
@@ -23200,7 +23222,7 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // FuncDef = "def", Identifier, Parameters, ":", Suite => ActionFn(1481);
+        // FuncDef = "def", Identifier, Parameters, ":", Suite => ActionFn(1482);
         assert!(__symbols.len() >= 5);
         let __sym4 = __pop_Variant25(__symbols);
         let __sym3 = __pop_Variant0(__symbols);
@@ -23209,7 +23231,7 @@ mod __parse__Top {
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym4.2;
-        let __nt = super::__action1481::<>(__sym0, __sym1, __sym2, __sym3, __sym4);
+        let __nt = super::__action1482::<>(__sym0, __sym1, __sym2, __sym3, __sym4);
         __symbols.push((__start, __Symbol::Variant35(__nt), __end));
         (5, 141)
     }
@@ -23220,17 +23242,17 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // FuncDef = Decorator+, "def", Identifier, Parameters, ":", Suite => ActionFn(1482);
+        // FuncDef = Decorator+, "def", Identifier, Parameters, ":", Suite => ActionFn(1483);
         assert!(__symbols.len() >= 6);
         let __sym5 = __pop_Variant25(__symbols);
         let __sym4 = __pop_Variant0(__symbols);
         let __sym3 = __pop_Variant44(__symbols);
         let __sym2 = __pop_Variant23(__symbols);
         let __sym1 = __pop_Variant0(__symbols);
-        let __sym0 = __pop_Variant17(__symbols);
+        let __sym0 = __pop_Variant56(__symbols);
         let __start = __sym0.0;
         let __end = __sym5.2;
-        let __nt = super::__action1482::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5);
+        let __nt = super::__action1483::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5);
         __symbols.push((__start, __Symbol::Variant35(__nt), __end));
         (6, 141)
     }
@@ -23241,13 +23263,13 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // FunctionArgument = NamedExpressionTest, CompFor => ActionFn(1465);
+        // FunctionArgument = NamedExpressionTest, CompFor => ActionFn(1466);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant51(__symbols);
         let __sym0 = __pop_Variant15(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action1465::<>(__sym0, __sym1);
+        let __nt = super::__action1466::<>(__sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant29(__nt), __end));
         (2, 142)
     }
@@ -23258,11 +23280,11 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // FunctionArgument = NamedExpressionTest => ActionFn(1466);
+        // FunctionArgument = NamedExpressionTest => ActionFn(1467);
         let __sym0 = __pop_Variant15(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action1466::<>(__sym0);
+        let __nt = super::__action1467::<>(__sym0);
         __symbols.push((__start, __Symbol::Variant29(__nt), __end));
         (1, 142)
     }
@@ -23273,14 +23295,14 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // FunctionArgument = Identifier, "=", Test<"all"> => ActionFn(1243);
+        // FunctionArgument = Identifier, "=", Test<"all"> => ActionFn(1244);
         assert!(__symbols.len() >= 3);
         let __sym2 = __pop_Variant15(__symbols);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant23(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
-        let __nt = super::__action1243::<>(__sym0, __sym1, __sym2);
+        let __nt = super::__action1244::<>(__sym0, __sym1, __sym2);
         __symbols.push((__start, __Symbol::Variant29(__nt), __end));
         (3, 142)
     }
@@ -23291,13 +23313,13 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // FunctionArgument = "*", Test<"all"> => ActionFn(1244);
+        // FunctionArgument = "*", Test<"all"> => ActionFn(1245);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant15(__symbols);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action1244::<>(__sym0, __sym1);
+        let __nt = super::__action1245::<>(__sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant29(__nt), __end));
         (2, 142)
     }
@@ -23308,13 +23330,13 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // FunctionArgument = "**", Test<"all"> => ActionFn(1245);
+        // FunctionArgument = "**", Test<"all"> => ActionFn(1246);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant15(__symbols);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action1245::<>(__sym0, __sym1);
+        let __nt = super::__action1246::<>(__sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant29(__nt), __end));
         (2, 142)
     }
@@ -23330,7 +23352,7 @@ mod __parse__Top {
         let __start = __sym0.0;
         let __end = __sym0.2;
         let __nt = super::__action419::<>(__sym0);
-        __symbols.push((__start, __Symbol::Variant61(__nt), __end));
+        __symbols.push((__start, __Symbol::Variant63(__nt), __end));
         (1, 143)
     }
     pub(crate) fn __reduce395<
@@ -23344,7 +23366,7 @@ mod __parse__Top {
         let __start = __lookahead_start.cloned().or_else(|| __symbols.last().map(|s| s.2.clone())).unwrap_or_default();
         let __end = __start.clone();
         let __nt = super::__action420::<>(&__start, &__end);
-        __symbols.push((__start, __Symbol::Variant61(__nt), __end));
+        __symbols.push((__start, __Symbol::Variant63(__nt), __end));
         (0, 143)
     }
     pub(crate) fn __reduce396<
@@ -23354,13 +23376,13 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // GenericList<ExpressionOrStarExpression> = OneOrMore<ExpressionOrStarExpression>, "," => ActionFn(1246);
+        // GenericList<ExpressionOrStarExpression> = OneOrMore<ExpressionOrStarExpression>, "," => ActionFn(1247);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant31(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action1246::<>(__sym0, __sym1);
+        let __nt = super::__action1247::<>(__sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant15(__nt), __end));
         (2, 144)
     }
@@ -23371,11 +23393,11 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // GenericList<ExpressionOrStarExpression> = OneOrMore<ExpressionOrStarExpression> => ActionFn(1247);
+        // GenericList<ExpressionOrStarExpression> = OneOrMore<ExpressionOrStarExpression> => ActionFn(1248);
         let __sym0 = __pop_Variant31(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action1247::<>(__sym0);
+        let __nt = super::__action1248::<>(__sym0);
         __symbols.push((__start, __Symbol::Variant15(__nt), __end));
         (1, 144)
     }
@@ -23386,13 +23408,13 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // GenericList<TestOrStarExpr> = OneOrMore<TestOrStarExpr>, "," => ActionFn(1248);
+        // GenericList<TestOrStarExpr> = OneOrMore<TestOrStarExpr>, "," => ActionFn(1249);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant31(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action1248::<>(__sym0, __sym1);
+        let __nt = super::__action1249::<>(__sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant15(__nt), __end));
         (2, 145)
     }
@@ -23403,11 +23425,11 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // GenericList<TestOrStarExpr> = OneOrMore<TestOrStarExpr> => ActionFn(1249);
+        // GenericList<TestOrStarExpr> = OneOrMore<TestOrStarExpr> => ActionFn(1250);
         let __sym0 = __pop_Variant31(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action1249::<>(__sym0);
+        let __nt = super::__action1250::<>(__sym0);
         __symbols.push((__start, __Symbol::Variant15(__nt), __end));
         (1, 145)
     }
@@ -23418,13 +23440,13 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // GlobalStatement = "global", OneOrMore<Identifier> => ActionFn(1250);
+        // GlobalStatement = "global", OneOrMore<Identifier> => ActionFn(1251);
         assert!(__symbols.len() >= 2);
-        let __sym1 = __pop_Variant71(__symbols);
+        let __sym1 = __pop_Variant73(__symbols);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action1250::<>(__sym0, __sym1);
+        let __nt = super::__action1251::<>(__sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant35(__nt), __end));
         (2, 146)
     }
@@ -23551,15 +23573,15 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // ImportAsAlias<DottedName> = DottedName, "as", Identifier => ActionFn(1251);
+        // ImportAsAlias<DottedName> = DottedName, "as", Identifier => ActionFn(1252);
         assert!(__symbols.len() >= 3);
         let __sym2 = __pop_Variant23(__symbols);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant23(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
-        let __nt = super::__action1251::<>(__sym0, __sym1, __sym2);
-        __symbols.push((__start, __Symbol::Variant62(__nt), __end));
+        let __nt = super::__action1252::<>(__sym0, __sym1, __sym2);
+        __symbols.push((__start, __Symbol::Variant64(__nt), __end));
         (3, 150)
     }
     pub(crate) fn __reduce408<
@@ -23569,12 +23591,12 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // ImportAsAlias<DottedName> = DottedName => ActionFn(1252);
+        // ImportAsAlias<DottedName> = DottedName => ActionFn(1253);
         let __sym0 = __pop_Variant23(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action1252::<>(__sym0);
-        __symbols.push((__start, __Symbol::Variant62(__nt), __end));
+        let __nt = super::__action1253::<>(__sym0);
+        __symbols.push((__start, __Symbol::Variant64(__nt), __end));
         (1, 150)
     }
     pub(crate) fn __reduce409<
@@ -23584,15 +23606,15 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // ImportAsAlias<Identifier> = Identifier, "as", Identifier => ActionFn(1253);
+        // ImportAsAlias<Identifier> = Identifier, "as", Identifier => ActionFn(1254);
         assert!(__symbols.len() >= 3);
         let __sym2 = __pop_Variant23(__symbols);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant23(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
-        let __nt = super::__action1253::<>(__sym0, __sym1, __sym2);
-        __symbols.push((__start, __Symbol::Variant62(__nt), __end));
+        let __nt = super::__action1254::<>(__sym0, __sym1, __sym2);
+        __symbols.push((__start, __Symbol::Variant64(__nt), __end));
         (3, 151)
     }
     pub(crate) fn __reduce410<
@@ -23602,12 +23624,12 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // ImportAsAlias<Identifier> = Identifier => ActionFn(1254);
+        // ImportAsAlias<Identifier> = Identifier => ActionFn(1255);
         let __sym0 = __pop_Variant23(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action1254::<>(__sym0);
-        __symbols.push((__start, __Symbol::Variant62(__nt), __end));
+        let __nt = super::__action1255::<>(__sym0);
+        __symbols.push((__start, __Symbol::Variant64(__nt), __end));
         (1, 151)
     }
     pub(crate) fn __reduce411<
@@ -23617,12 +23639,12 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // ImportAsNames = OneOrMore<ImportAsAlias<Identifier>> => ActionFn(1255);
-        let __sym0 = __pop_Variant63(__symbols);
+        // ImportAsNames = OneOrMore<ImportAsAlias<Identifier>> => ActionFn(1256);
+        let __sym0 = __pop_Variant65(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action1255::<>(__sym0);
-        __symbols.push((__start, __Symbol::Variant63(__nt), __end));
+        let __nt = super::__action1256::<>(__sym0);
+        __symbols.push((__start, __Symbol::Variant65(__nt), __end));
         (1, 152)
     }
     pub(crate) fn __reduce412<
@@ -23632,16 +23654,16 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // ImportAsNames = "(", OneOrMore<ImportAsAlias<Identifier>>, ",", ")" => ActionFn(1256);
+        // ImportAsNames = "(", OneOrMore<ImportAsAlias<Identifier>>, ",", ")" => ActionFn(1257);
         assert!(__symbols.len() >= 4);
         let __sym3 = __pop_Variant0(__symbols);
         let __sym2 = __pop_Variant0(__symbols);
-        let __sym1 = __pop_Variant63(__symbols);
+        let __sym1 = __pop_Variant65(__symbols);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym3.2;
-        let __nt = super::__action1256::<>(__sym0, __sym1, __sym2, __sym3);
-        __symbols.push((__start, __Symbol::Variant63(__nt), __end));
+        let __nt = super::__action1257::<>(__sym0, __sym1, __sym2, __sym3);
+        __symbols.push((__start, __Symbol::Variant65(__nt), __end));
         (4, 152)
     }
     pub(crate) fn __reduce413<
@@ -23651,15 +23673,15 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // ImportAsNames = "(", OneOrMore<ImportAsAlias<Identifier>>, ")" => ActionFn(1257);
+        // ImportAsNames = "(", OneOrMore<ImportAsAlias<Identifier>>, ")" => ActionFn(1258);
         assert!(__symbols.len() >= 3);
         let __sym2 = __pop_Variant0(__symbols);
-        let __sym1 = __pop_Variant63(__symbols);
+        let __sym1 = __pop_Variant65(__symbols);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
-        let __nt = super::__action1257::<>(__sym0, __sym1, __sym2);
-        __symbols.push((__start, __Symbol::Variant63(__nt), __end));
+        let __nt = super::__action1258::<>(__sym0, __sym1, __sym2);
+        __symbols.push((__start, __Symbol::Variant65(__nt), __end));
         (3, 152)
     }
     pub(crate) fn __reduce414<
@@ -23669,12 +23691,12 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // ImportAsNames = "*" => ActionFn(1258);
+        // ImportAsNames = "*" => ActionFn(1259);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action1258::<>(__sym0);
-        __symbols.push((__start, __Symbol::Variant63(__nt), __end));
+        let __nt = super::__action1259::<>(__sym0);
+        __symbols.push((__start, __Symbol::Variant65(__nt), __end));
         (1, 152)
     }
     pub(crate) fn __reduce415<
@@ -23689,7 +23711,7 @@ mod __parse__Top {
         let __start = __sym0.0;
         let __end = __sym0.2;
         let __nt = super::__action61::<>(__sym0);
-        __symbols.push((__start, __Symbol::Variant64(__nt), __end));
+        __symbols.push((__start, __Symbol::Variant66(__nt), __end));
         (1, 153)
     }
     pub(crate) fn __reduce416<
@@ -23704,7 +23726,7 @@ mod __parse__Top {
         let __start = __sym0.0;
         let __end = __sym0.2;
         let __nt = super::__action62::<>(__sym0);
-        __symbols.push((__start, __Symbol::Variant64(__nt), __end));
+        __symbols.push((__start, __Symbol::Variant66(__nt), __end));
         (1, 153)
     }
     pub(crate) fn __reduce417<
@@ -23718,7 +23740,7 @@ mod __parse__Top {
         let __start = __lookahead_start.cloned().or_else(|| __symbols.last().map(|s| s.2.clone())).unwrap_or_default();
         let __end = __start.clone();
         let __nt = super::__action345::<>(&__start, &__end);
-        __symbols.push((__start, __Symbol::Variant65(__nt), __end));
+        __symbols.push((__start, __Symbol::Variant67(__nt), __end));
         (0, 154)
     }
     pub(crate) fn __reduce418<
@@ -23729,11 +23751,11 @@ mod __parse__Top {
     ) -> (usize, usize)
     {
         // ImportDots* = ImportDots+ => ActionFn(346);
-        let __sym0 = __pop_Variant65(__symbols);
+        let __sym0 = __pop_Variant67(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
         let __nt = super::__action346::<>(__sym0);
-        __symbols.push((__start, __Symbol::Variant65(__nt), __end));
+        __symbols.push((__start, __Symbol::Variant67(__nt), __end));
         (1, 154)
     }
     pub(crate) fn __reduce419<
@@ -23744,11 +23766,11 @@ mod __parse__Top {
     ) -> (usize, usize)
     {
         // ImportDots+ = ImportDots => ActionFn(343);
-        let __sym0 = __pop_Variant64(__symbols);
+        let __sym0 = __pop_Variant66(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
         let __nt = super::__action343::<>(__sym0);
-        __symbols.push((__start, __Symbol::Variant65(__nt), __end));
+        __symbols.push((__start, __Symbol::Variant67(__nt), __end));
         (1, 155)
     }
     pub(crate) fn __reduce420<
@@ -23760,12 +23782,12 @@ mod __parse__Top {
     {
         // ImportDots+ = ImportDots+, ImportDots => ActionFn(344);
         assert!(__symbols.len() >= 2);
-        let __sym1 = __pop_Variant64(__symbols);
-        let __sym0 = __pop_Variant65(__symbols);
+        let __sym1 = __pop_Variant66(__symbols);
+        let __sym0 = __pop_Variant67(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
         let __nt = super::__action344::<>(__sym0, __sym1);
-        __symbols.push((__start, __Symbol::Variant65(__nt), __end));
+        __symbols.push((__start, __Symbol::Variant67(__nt), __end));
         (2, 155)
     }
     pub(crate) fn __reduce421<
@@ -23775,12 +23797,12 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // ImportFromLocation = DottedName => ActionFn(1495);
+        // ImportFromLocation = DottedName => ActionFn(1496);
         let __sym0 = __pop_Variant23(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action1495::<>(__sym0);
-        __symbols.push((__start, __Symbol::Variant66(__nt), __end));
+        let __nt = super::__action1496::<>(__sym0);
+        __symbols.push((__start, __Symbol::Variant68(__nt), __end));
         (1, 156)
     }
     pub(crate) fn __reduce422<
@@ -23790,14 +23812,14 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // ImportFromLocation = ImportDots+, DottedName => ActionFn(1496);
+        // ImportFromLocation = ImportDots+, DottedName => ActionFn(1497);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant23(__symbols);
-        let __sym0 = __pop_Variant65(__symbols);
+        let __sym0 = __pop_Variant67(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action1496::<>(__sym0, __sym1);
-        __symbols.push((__start, __Symbol::Variant66(__nt), __end));
+        let __nt = super::__action1497::<>(__sym0, __sym1);
+        __symbols.push((__start, __Symbol::Variant68(__nt), __end));
         (2, 156)
     }
     pub(crate) fn __reduce423<
@@ -23808,11 +23830,11 @@ mod __parse__Top {
     ) -> (usize, usize)
     {
         // ImportFromLocation = ImportDots+ => ActionFn(60);
-        let __sym0 = __pop_Variant65(__symbols);
+        let __sym0 = __pop_Variant67(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
         let __nt = super::__action60::<>(__sym0);
-        __symbols.push((__start, __Symbol::Variant66(__nt), __end));
+        __symbols.push((__start, __Symbol::Variant68(__nt), __end));
         (1, 156)
     }
     pub(crate) fn __reduce424<
@@ -23822,13 +23844,13 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // ImportStatement = "import", OneOrMore<ImportAsAlias<DottedName>> => ActionFn(1259);
+        // ImportStatement = "import", OneOrMore<ImportAsAlias<DottedName>> => ActionFn(1260);
         assert!(__symbols.len() >= 2);
-        let __sym1 = __pop_Variant63(__symbols);
+        let __sym1 = __pop_Variant65(__symbols);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action1259::<>(__sym0, __sym1);
+        let __nt = super::__action1260::<>(__sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant35(__nt), __end));
         (2, 157)
     }
@@ -23839,15 +23861,15 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // ImportStatement = "from", ImportFromLocation, "import", ImportAsNames => ActionFn(1260);
+        // ImportStatement = "from", ImportFromLocation, "import", ImportAsNames => ActionFn(1261);
         assert!(__symbols.len() >= 4);
-        let __sym3 = __pop_Variant63(__symbols);
+        let __sym3 = __pop_Variant65(__symbols);
         let __sym2 = __pop_Variant0(__symbols);
-        let __sym1 = __pop_Variant66(__symbols);
+        let __sym1 = __pop_Variant68(__symbols);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym3.2;
-        let __nt = super::__action1260::<>(__sym0, __sym1, __sym2, __sym3);
+        let __nt = super::__action1261::<>(__sym0, __sym1, __sym2, __sym3);
         __symbols.push((__start, __Symbol::Variant35(__nt), __end));
         (4, 157)
     }
@@ -23858,13 +23880,13 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // KwargParameter<TypedParameter> = "**", TypedParameter => ActionFn(1653);
+        // KwargParameter<TypedParameter> = "**", TypedParameter => ActionFn(1654);
         assert!(__symbols.len() >= 2);
-        let __sym1 = __pop_Variant81(__symbols);
+        let __sym1 = __pop_Variant83(__symbols);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action1653::<>(__sym0, __sym1);
+        let __nt = super::__action1654::<>(__sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant9(__nt), __end));
         (2, 158)
     }
@@ -23875,11 +23897,11 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // KwargParameter<TypedParameter> = "**" => ActionFn(1654);
+        // KwargParameter<TypedParameter> = "**" => ActionFn(1655);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action1654::<>(__sym0);
+        let __nt = super::__action1655::<>(__sym0);
         __symbols.push((__start, __Symbol::Variant9(__nt), __end));
         (1, 158)
     }
@@ -23892,7 +23914,7 @@ mod __parse__Top {
     {
         // KwargParameter<UntypedParameter> = "**", UntypedParameter => ActionFn(962);
         assert!(__symbols.len() >= 2);
-        let __sym1 = __pop_Variant81(__symbols);
+        let __sym1 = __pop_Variant83(__symbols);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
@@ -23983,11 +24005,11 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // LiteralPattern = "None" => ActionFn(1262);
+        // LiteralPattern = "None" => ActionFn(1263);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action1262::<>(__sym0);
+        let __nt = super::__action1263::<>(__sym0);
         __symbols.push((__start, __Symbol::Variant33(__nt), __end));
         (1, 163)
     }
@@ -23998,11 +24020,11 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // LiteralPattern = "True" => ActionFn(1263);
+        // LiteralPattern = "True" => ActionFn(1264);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action1263::<>(__sym0);
+        let __nt = super::__action1264::<>(__sym0);
         __symbols.push((__start, __Symbol::Variant33(__nt), __end));
         (1, 163)
     }
@@ -24013,11 +24035,11 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // LiteralPattern = "False" => ActionFn(1264);
+        // LiteralPattern = "False" => ActionFn(1265);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action1264::<>(__sym0);
+        let __nt = super::__action1265::<>(__sym0);
         __symbols.push((__start, __Symbol::Variant33(__nt), __end));
         (1, 163)
     }
@@ -24028,11 +24050,11 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // LiteralPattern = ConstantExpr => ActionFn(1265);
+        // LiteralPattern = ConstantExpr => ActionFn(1266);
         let __sym0 = __pop_Variant15(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action1265::<>(__sym0);
+        let __nt = super::__action1266::<>(__sym0);
         __symbols.push((__start, __Symbol::Variant33(__nt), __end));
         (1, 163)
     }
@@ -24043,11 +24065,11 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // LiteralPattern = AddOpExpr => ActionFn(1266);
+        // LiteralPattern = AddOpExpr => ActionFn(1267);
         let __sym0 = __pop_Variant15(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action1266::<>(__sym0);
+        let __nt = super::__action1267::<>(__sym0);
         __symbols.push((__start, __Symbol::Variant33(__nt), __end));
         (1, 163)
     }
@@ -24103,11 +24125,11 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // MappingKey = "None" => ActionFn(1268);
+        // MappingKey = "None" => ActionFn(1269);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action1268::<>(__sym0);
+        let __nt = super::__action1269::<>(__sym0);
         __symbols.push((__start, __Symbol::Variant15(__nt), __end));
         (1, 164)
     }
@@ -24118,11 +24140,11 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // MappingKey = "True" => ActionFn(1269);
+        // MappingKey = "True" => ActionFn(1270);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action1269::<>(__sym0);
+        let __nt = super::__action1270::<>(__sym0);
         __symbols.push((__start, __Symbol::Variant15(__nt), __end));
         (1, 164)
     }
@@ -24133,11 +24155,11 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // MappingKey = "False" => ActionFn(1270);
+        // MappingKey = "False" => ActionFn(1271);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action1270::<>(__sym0);
+        let __nt = super::__action1271::<>(__sym0);
         __symbols.push((__start, __Symbol::Variant15(__nt), __end));
         (1, 164)
     }
@@ -24148,13 +24170,13 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // MappingPattern = "{", "}" => ActionFn(1271);
+        // MappingPattern = "{", "}" => ActionFn(1272);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action1271::<>(__sym0, __sym1);
+        let __nt = super::__action1272::<>(__sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant33(__nt), __end));
         (2, 165)
     }
@@ -24165,15 +24187,15 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // MappingPattern = "{", OneOrMore<MatchMappingEntry>, ",", "}" => ActionFn(1272);
+        // MappingPattern = "{", OneOrMore<MatchMappingEntry>, ",", "}" => ActionFn(1273);
         assert!(__symbols.len() >= 4);
         let __sym3 = __pop_Variant0(__symbols);
         let __sym2 = __pop_Variant0(__symbols);
-        let __sym1 = __pop_Variant73(__symbols);
+        let __sym1 = __pop_Variant75(__symbols);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym3.2;
-        let __nt = super::__action1272::<>(__sym0, __sym1, __sym2, __sym3);
+        let __nt = super::__action1273::<>(__sym0, __sym1, __sym2, __sym3);
         __symbols.push((__start, __Symbol::Variant33(__nt), __end));
         (4, 165)
     }
@@ -24184,14 +24206,14 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // MappingPattern = "{", OneOrMore<MatchMappingEntry>, "}" => ActionFn(1273);
+        // MappingPattern = "{", OneOrMore<MatchMappingEntry>, "}" => ActionFn(1274);
         assert!(__symbols.len() >= 3);
         let __sym2 = __pop_Variant0(__symbols);
-        let __sym1 = __pop_Variant73(__symbols);
+        let __sym1 = __pop_Variant75(__symbols);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
-        let __nt = super::__action1273::<>(__sym0, __sym1, __sym2);
+        let __nt = super::__action1274::<>(__sym0, __sym1, __sym2);
         __symbols.push((__start, __Symbol::Variant33(__nt), __end));
         (3, 165)
     }
@@ -24202,7 +24224,7 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // MappingPattern = "{", "**", Identifier, ",", "}" => ActionFn(1274);
+        // MappingPattern = "{", "**", Identifier, ",", "}" => ActionFn(1275);
         assert!(__symbols.len() >= 5);
         let __sym4 = __pop_Variant0(__symbols);
         let __sym3 = __pop_Variant0(__symbols);
@@ -24211,7 +24233,7 @@ mod __parse__Top {
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym4.2;
-        let __nt = super::__action1274::<>(__sym0, __sym1, __sym2, __sym3, __sym4);
+        let __nt = super::__action1275::<>(__sym0, __sym1, __sym2, __sym3, __sym4);
         __symbols.push((__start, __Symbol::Variant33(__nt), __end));
         (5, 165)
     }
@@ -24222,7 +24244,7 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // MappingPattern = "{", "**", Identifier, "}" => ActionFn(1275);
+        // MappingPattern = "{", "**", Identifier, "}" => ActionFn(1276);
         assert!(__symbols.len() >= 4);
         let __sym3 = __pop_Variant0(__symbols);
         let __sym2 = __pop_Variant23(__symbols);
@@ -24230,7 +24252,7 @@ mod __parse__Top {
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym3.2;
-        let __nt = super::__action1275::<>(__sym0, __sym1, __sym2, __sym3);
+        let __nt = super::__action1276::<>(__sym0, __sym1, __sym2, __sym3);
         __symbols.push((__start, __Symbol::Variant33(__nt), __end));
         (4, 165)
     }
@@ -24241,18 +24263,18 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // MappingPattern = "{", OneOrMore<MatchMappingEntry>, ",", "**", Identifier, ",", "}" => ActionFn(1276);
+        // MappingPattern = "{", OneOrMore<MatchMappingEntry>, ",", "**", Identifier, ",", "}" => ActionFn(1277);
         assert!(__symbols.len() >= 7);
         let __sym6 = __pop_Variant0(__symbols);
         let __sym5 = __pop_Variant0(__symbols);
         let __sym4 = __pop_Variant23(__symbols);
         let __sym3 = __pop_Variant0(__symbols);
         let __sym2 = __pop_Variant0(__symbols);
-        let __sym1 = __pop_Variant73(__symbols);
+        let __sym1 = __pop_Variant75(__symbols);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym6.2;
-        let __nt = super::__action1276::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6);
+        let __nt = super::__action1277::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6);
         __symbols.push((__start, __Symbol::Variant33(__nt), __end));
         (7, 165)
     }
@@ -24263,17 +24285,17 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // MappingPattern = "{", OneOrMore<MatchMappingEntry>, ",", "**", Identifier, "}" => ActionFn(1277);
+        // MappingPattern = "{", OneOrMore<MatchMappingEntry>, ",", "**", Identifier, "}" => ActionFn(1278);
         assert!(__symbols.len() >= 6);
         let __sym5 = __pop_Variant0(__symbols);
         let __sym4 = __pop_Variant23(__symbols);
         let __sym3 = __pop_Variant0(__symbols);
         let __sym2 = __pop_Variant0(__symbols);
-        let __sym1 = __pop_Variant73(__symbols);
+        let __sym1 = __pop_Variant75(__symbols);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym5.2;
-        let __nt = super::__action1277::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5);
+        let __nt = super::__action1278::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5);
         __symbols.push((__start, __Symbol::Variant33(__nt), __end));
         (6, 165)
     }
@@ -24284,7 +24306,7 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // MatchCase = "case", Patterns, Guard, ":", Suite => ActionFn(1440);
+        // MatchCase = "case", Patterns, Guard, ":", Suite => ActionFn(1441);
         assert!(__symbols.len() >= 5);
         let __sym4 = __pop_Variant25(__symbols);
         let __sym3 = __pop_Variant0(__symbols);
@@ -24293,8 +24315,8 @@ mod __parse__Top {
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym4.2;
-        let __nt = super::__action1440::<>(__sym0, __sym1, __sym2, __sym3, __sym4);
-        __symbols.push((__start, __Symbol::Variant67(__nt), __end));
+        let __nt = super::__action1441::<>(__sym0, __sym1, __sym2, __sym3, __sym4);
+        __symbols.push((__start, __Symbol::Variant69(__nt), __end));
         (5, 166)
     }
     pub(crate) fn __reduce457<
@@ -24304,7 +24326,7 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // MatchCase = "case", Patterns, ":", Suite => ActionFn(1441);
+        // MatchCase = "case", Patterns, ":", Suite => ActionFn(1442);
         assert!(__symbols.len() >= 4);
         let __sym3 = __pop_Variant25(__symbols);
         let __sym2 = __pop_Variant0(__symbols);
@@ -24312,8 +24334,8 @@ mod __parse__Top {
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym3.2;
-        let __nt = super::__action1441::<>(__sym0, __sym1, __sym2, __sym3);
-        __symbols.push((__start, __Symbol::Variant67(__nt), __end));
+        let __nt = super::__action1442::<>(__sym0, __sym1, __sym2, __sym3);
+        __symbols.push((__start, __Symbol::Variant69(__nt), __end));
         (4, 166)
     }
     pub(crate) fn __reduce458<
@@ -24324,11 +24346,11 @@ mod __parse__Top {
     ) -> (usize, usize)
     {
         // MatchCase+ = MatchCase => ActionFn(328);
-        let __sym0 = __pop_Variant67(__symbols);
+        let __sym0 = __pop_Variant69(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
         let __nt = super::__action328::<>(__sym0);
-        __symbols.push((__start, __Symbol::Variant68(__nt), __end));
+        __symbols.push((__start, __Symbol::Variant70(__nt), __end));
         (1, 167)
     }
     pub(crate) fn __reduce459<
@@ -24340,12 +24362,12 @@ mod __parse__Top {
     {
         // MatchCase+ = MatchCase+, MatchCase => ActionFn(329);
         assert!(__symbols.len() >= 2);
-        let __sym1 = __pop_Variant67(__symbols);
-        let __sym0 = __pop_Variant68(__symbols);
+        let __sym1 = __pop_Variant69(__symbols);
+        let __sym0 = __pop_Variant70(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
         let __nt = super::__action329::<>(__sym0, __sym1);
-        __symbols.push((__start, __Symbol::Variant68(__nt), __end));
+        __symbols.push((__start, __Symbol::Variant70(__nt), __end));
         (2, 167)
     }
     pub(crate) fn __reduce460<
@@ -24363,7 +24385,7 @@ mod __parse__Top {
         let __start = __sym0.0;
         let __end = __sym2.2;
         let __nt = super::__action132::<>(__sym0, __sym1, __sym2);
-        __symbols.push((__start, __Symbol::Variant69(__nt), __end));
+        __symbols.push((__start, __Symbol::Variant71(__nt), __end));
         (3, 168)
     }
     pub(crate) fn __reduce461<
@@ -24381,7 +24403,7 @@ mod __parse__Top {
         let __start = __sym0.0;
         let __end = __sym2.2;
         let __nt = super::__action127::<>(__sym0, __sym1, __sym2);
-        __symbols.push((__start, __Symbol::Variant70(__nt), __end));
+        __symbols.push((__start, __Symbol::Variant72(__nt), __end));
         (3, 169)
     }
     pub(crate) fn __reduce462<
@@ -24391,11 +24413,11 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // MatchName = Identifier => ActionFn(1278);
+        // MatchName = Identifier => ActionFn(1279);
         let __sym0 = __pop_Variant23(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action1278::<>(__sym0);
+        let __nt = super::__action1279::<>(__sym0);
         __symbols.push((__start, __Symbol::Variant15(__nt), __end));
         (1, 170)
     }
@@ -24406,14 +24428,14 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // MatchNameOrAttr = MatchName, ".", Identifier => ActionFn(1279);
+        // MatchNameOrAttr = MatchName, ".", Identifier => ActionFn(1280);
         assert!(__symbols.len() >= 3);
         let __sym2 = __pop_Variant23(__symbols);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant15(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
-        let __nt = super::__action1279::<>(__sym0, __sym1, __sym2);
+        let __nt = super::__action1280::<>(__sym0, __sym1, __sym2);
         __symbols.push((__start, __Symbol::Variant15(__nt), __end));
         (3, 171)
     }
@@ -24424,14 +24446,14 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // MatchNameOrAttr = MatchNameOrAttr, ".", Identifier => ActionFn(1280);
+        // MatchNameOrAttr = MatchNameOrAttr, ".", Identifier => ActionFn(1281);
         assert!(__symbols.len() >= 3);
         let __sym2 = __pop_Variant23(__symbols);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant15(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
-        let __nt = super::__action1280::<>(__sym0, __sym1, __sym2);
+        let __nt = super::__action1281::<>(__sym0, __sym1, __sym2);
         __symbols.push((__start, __Symbol::Variant15(__nt), __end));
         (3, 171)
     }
@@ -24445,7 +24467,7 @@ mod __parse__Top {
         // MatchStatement = "match", TestOrStarNamedExpr, ":", "\n", Indent, MatchCase+, Dedent => ActionFn(819);
         assert!(__symbols.len() >= 7);
         let __sym6 = __pop_Variant0(__symbols);
-        let __sym5 = __pop_Variant68(__symbols);
+        let __sym5 = __pop_Variant70(__symbols);
         let __sym4 = __pop_Variant0(__symbols);
         let __sym3 = __pop_Variant0(__symbols);
         let __sym2 = __pop_Variant0(__symbols);
@@ -24467,7 +24489,7 @@ mod __parse__Top {
         // MatchStatement = "match", TestOrStarNamedExpr, ",", ":", "\n", Indent, MatchCase+, Dedent => ActionFn(820);
         assert!(__symbols.len() >= 8);
         let __sym7 = __pop_Variant0(__symbols);
-        let __sym6 = __pop_Variant68(__symbols);
+        let __sym6 = __pop_Variant70(__symbols);
         let __sym5 = __pop_Variant0(__symbols);
         let __sym4 = __pop_Variant0(__symbols);
         let __sym3 = __pop_Variant0(__symbols);
@@ -24490,7 +24512,7 @@ mod __parse__Top {
         // MatchStatement = "match", TwoOrMore<TestOrStarNamedExpr, ",">, ",", ":", "\n", Indent, MatchCase+, Dedent => ActionFn(821);
         assert!(__symbols.len() >= 8);
         let __sym7 = __pop_Variant0(__symbols);
-        let __sym6 = __pop_Variant68(__symbols);
+        let __sym6 = __pop_Variant70(__symbols);
         let __sym5 = __pop_Variant0(__symbols);
         let __sym4 = __pop_Variant0(__symbols);
         let __sym3 = __pop_Variant0(__symbols);
@@ -24513,7 +24535,7 @@ mod __parse__Top {
         // MatchStatement = "match", TwoOrMore<TestOrStarNamedExpr, ",">, ":", "\n", Indent, MatchCase+, Dedent => ActionFn(822);
         assert!(__symbols.len() >= 7);
         let __sym6 = __pop_Variant0(__symbols);
-        let __sym5 = __pop_Variant68(__symbols);
+        let __sym5 = __pop_Variant70(__symbols);
         let __sym4 = __pop_Variant0(__symbols);
         let __sym3 = __pop_Variant0(__symbols);
         let __sym2 = __pop_Variant0(__symbols);
@@ -24607,14 +24629,14 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // NamedExpression = Identifier, ":=", Test<"all"> => ActionFn(1281);
+        // NamedExpression = Identifier, ":=", Test<"all"> => ActionFn(1282);
         assert!(__symbols.len() >= 3);
         let __sym2 = __pop_Variant15(__symbols);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant23(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
-        let __nt = super::__action1281::<>(__sym0, __sym1, __sym2);
+        let __nt = super::__action1282::<>(__sym0, __sym1, __sym2);
         __symbols.push((__start, __Symbol::Variant15(__nt), __end));
         (3, 174)
     }
@@ -24685,13 +24707,13 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // NonlocalStatement = "nonlocal", OneOrMore<Identifier> => ActionFn(1282);
+        // NonlocalStatement = "nonlocal", OneOrMore<Identifier> => ActionFn(1283);
         assert!(__symbols.len() >= 2);
-        let __sym1 = __pop_Variant71(__symbols);
+        let __sym1 = __pop_Variant73(__symbols);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action1282::<>(__sym0, __sym1);
+        let __nt = super::__action1283::<>(__sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant35(__nt), __end));
         (2, 177)
     }
@@ -24702,13 +24724,13 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // NotTest<"all"> = "not", NotTest<"all"> => ActionFn(1283);
+        // NotTest<"all"> = "not", NotTest<"all"> => ActionFn(1284);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant15(__symbols);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action1283::<>(__sym0, __sym1);
+        let __nt = super::__action1284::<>(__sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant15(__nt), __end));
         (2, 178)
     }
@@ -24734,13 +24756,13 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // NotTest<"no-withitems"> = "not", NotTest<"all"> => ActionFn(1284);
+        // NotTest<"no-withitems"> = "not", NotTest<"all"> => ActionFn(1285);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant15(__symbols);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action1284::<>(__sym0, __sym1);
+        let __nt = super::__action1285::<>(__sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant15(__nt), __end));
         (2, 179)
     }
@@ -24767,11 +24789,11 @@ mod __parse__Top {
     ) -> (usize, usize)
     {
         // OneOrMore<DictElement> = DictElement => ActionFn(238);
-        let __sym0 = __pop_Variant55(__symbols);
+        let __sym0 = __pop_Variant57(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
         let __nt = super::__action238::<>(__sym0);
-        __symbols.push((__start, __Symbol::Variant57(__nt), __end));
+        __symbols.push((__start, __Symbol::Variant59(__nt), __end));
         (1, 180)
     }
     pub(crate) fn __reduce485<
@@ -24783,13 +24805,13 @@ mod __parse__Top {
     {
         // OneOrMore<DictElement> = OneOrMore<DictElement>, ",", DictElement => ActionFn(239);
         assert!(__symbols.len() >= 3);
-        let __sym2 = __pop_Variant55(__symbols);
+        let __sym2 = __pop_Variant57(__symbols);
         let __sym1 = __pop_Variant0(__symbols);
-        let __sym0 = __pop_Variant57(__symbols);
+        let __sym0 = __pop_Variant59(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
         let __nt = super::__action239::<>(__sym0, __sym1, __sym2);
-        __symbols.push((__start, __Symbol::Variant57(__nt), __end));
+        __symbols.push((__start, __Symbol::Variant59(__nt), __end));
         (3, 180)
     }
     pub(crate) fn __reduce486<
@@ -24837,7 +24859,7 @@ mod __parse__Top {
         let __start = __sym0.0;
         let __end = __sym0.2;
         let __nt = super::__action333::<>(__sym0);
-        __symbols.push((__start, __Symbol::Variant71(__nt), __end));
+        __symbols.push((__start, __Symbol::Variant73(__nt), __end));
         (1, 182)
     }
     pub(crate) fn __reduce489<
@@ -24851,11 +24873,11 @@ mod __parse__Top {
         assert!(__symbols.len() >= 3);
         let __sym2 = __pop_Variant23(__symbols);
         let __sym1 = __pop_Variant0(__symbols);
-        let __sym0 = __pop_Variant71(__symbols);
+        let __sym0 = __pop_Variant73(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
         let __nt = super::__action334::<>(__sym0, __sym1, __sym2);
-        __symbols.push((__start, __Symbol::Variant71(__nt), __end));
+        __symbols.push((__start, __Symbol::Variant73(__nt), __end));
         (3, 182)
     }
     pub(crate) fn __reduce490<
@@ -24865,15 +24887,15 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // OneOrMore<ImportAsAlias<DottedName>> = DottedName, "as", Identifier => ActionFn(1487);
+        // OneOrMore<ImportAsAlias<DottedName>> = DottedName, "as", Identifier => ActionFn(1488);
         assert!(__symbols.len() >= 3);
         let __sym2 = __pop_Variant23(__symbols);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant23(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
-        let __nt = super::__action1487::<>(__sym0, __sym1, __sym2);
-        __symbols.push((__start, __Symbol::Variant63(__nt), __end));
+        let __nt = super::__action1488::<>(__sym0, __sym1, __sym2);
+        __symbols.push((__start, __Symbol::Variant65(__nt), __end));
         (3, 183)
     }
     pub(crate) fn __reduce491<
@@ -24883,12 +24905,12 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // OneOrMore<ImportAsAlias<DottedName>> = DottedName => ActionFn(1488);
+        // OneOrMore<ImportAsAlias<DottedName>> = DottedName => ActionFn(1489);
         let __sym0 = __pop_Variant23(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action1488::<>(__sym0);
-        __symbols.push((__start, __Symbol::Variant63(__nt), __end));
+        let __nt = super::__action1489::<>(__sym0);
+        __symbols.push((__start, __Symbol::Variant65(__nt), __end));
         (1, 183)
     }
     pub(crate) fn __reduce492<
@@ -24898,17 +24920,17 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // OneOrMore<ImportAsAlias<DottedName>> = OneOrMore<ImportAsAlias<DottedName>>, ",", DottedName, "as", Identifier => ActionFn(1489);
+        // OneOrMore<ImportAsAlias<DottedName>> = OneOrMore<ImportAsAlias<DottedName>>, ",", DottedName, "as", Identifier => ActionFn(1490);
         assert!(__symbols.len() >= 5);
         let __sym4 = __pop_Variant23(__symbols);
         let __sym3 = __pop_Variant0(__symbols);
         let __sym2 = __pop_Variant23(__symbols);
         let __sym1 = __pop_Variant0(__symbols);
-        let __sym0 = __pop_Variant63(__symbols);
+        let __sym0 = __pop_Variant65(__symbols);
         let __start = __sym0.0;
         let __end = __sym4.2;
-        let __nt = super::__action1489::<>(__sym0, __sym1, __sym2, __sym3, __sym4);
-        __symbols.push((__start, __Symbol::Variant63(__nt), __end));
+        let __nt = super::__action1490::<>(__sym0, __sym1, __sym2, __sym3, __sym4);
+        __symbols.push((__start, __Symbol::Variant65(__nt), __end));
         (5, 183)
     }
     pub(crate) fn __reduce493<
@@ -24918,15 +24940,15 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // OneOrMore<ImportAsAlias<DottedName>> = OneOrMore<ImportAsAlias<DottedName>>, ",", DottedName => ActionFn(1490);
+        // OneOrMore<ImportAsAlias<DottedName>> = OneOrMore<ImportAsAlias<DottedName>>, ",", DottedName => ActionFn(1491);
         assert!(__symbols.len() >= 3);
         let __sym2 = __pop_Variant23(__symbols);
         let __sym1 = __pop_Variant0(__symbols);
-        let __sym0 = __pop_Variant63(__symbols);
+        let __sym0 = __pop_Variant65(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
-        let __nt = super::__action1490::<>(__sym0, __sym1, __sym2);
-        __symbols.push((__start, __Symbol::Variant63(__nt), __end));
+        let __nt = super::__action1491::<>(__sym0, __sym1, __sym2);
+        __symbols.push((__start, __Symbol::Variant65(__nt), __end));
         (3, 183)
     }
     pub(crate) fn __reduce494<
@@ -24936,15 +24958,15 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // OneOrMore<ImportAsAlias<Identifier>> = Identifier, "as", Identifier => ActionFn(1491);
+        // OneOrMore<ImportAsAlias<Identifier>> = Identifier, "as", Identifier => ActionFn(1492);
         assert!(__symbols.len() >= 3);
         let __sym2 = __pop_Variant23(__symbols);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant23(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
-        let __nt = super::__action1491::<>(__sym0, __sym1, __sym2);
-        __symbols.push((__start, __Symbol::Variant63(__nt), __end));
+        let __nt = super::__action1492::<>(__sym0, __sym1, __sym2);
+        __symbols.push((__start, __Symbol::Variant65(__nt), __end));
         (3, 184)
     }
     pub(crate) fn __reduce495<
@@ -24954,12 +24976,12 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // OneOrMore<ImportAsAlias<Identifier>> = Identifier => ActionFn(1492);
+        // OneOrMore<ImportAsAlias<Identifier>> = Identifier => ActionFn(1493);
         let __sym0 = __pop_Variant23(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action1492::<>(__sym0);
-        __symbols.push((__start, __Symbol::Variant63(__nt), __end));
+        let __nt = super::__action1493::<>(__sym0);
+        __symbols.push((__start, __Symbol::Variant65(__nt), __end));
         (1, 184)
     }
     pub(crate) fn __reduce496<
@@ -24969,17 +24991,17 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // OneOrMore<ImportAsAlias<Identifier>> = OneOrMore<ImportAsAlias<Identifier>>, ",", Identifier, "as", Identifier => ActionFn(1493);
+        // OneOrMore<ImportAsAlias<Identifier>> = OneOrMore<ImportAsAlias<Identifier>>, ",", Identifier, "as", Identifier => ActionFn(1494);
         assert!(__symbols.len() >= 5);
         let __sym4 = __pop_Variant23(__symbols);
         let __sym3 = __pop_Variant0(__symbols);
         let __sym2 = __pop_Variant23(__symbols);
         let __sym1 = __pop_Variant0(__symbols);
-        let __sym0 = __pop_Variant63(__symbols);
+        let __sym0 = __pop_Variant65(__symbols);
         let __start = __sym0.0;
         let __end = __sym4.2;
-        let __nt = super::__action1493::<>(__sym0, __sym1, __sym2, __sym3, __sym4);
-        __symbols.push((__start, __Symbol::Variant63(__nt), __end));
+        let __nt = super::__action1494::<>(__sym0, __sym1, __sym2, __sym3, __sym4);
+        __symbols.push((__start, __Symbol::Variant65(__nt), __end));
         (5, 184)
     }
     pub(crate) fn __reduce497<
@@ -24989,15 +25011,15 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // OneOrMore<ImportAsAlias<Identifier>> = OneOrMore<ImportAsAlias<Identifier>>, ",", Identifier => ActionFn(1494);
+        // OneOrMore<ImportAsAlias<Identifier>> = OneOrMore<ImportAsAlias<Identifier>>, ",", Identifier => ActionFn(1495);
         assert!(__symbols.len() >= 3);
         let __sym2 = __pop_Variant23(__symbols);
         let __sym1 = __pop_Variant0(__symbols);
-        let __sym0 = __pop_Variant63(__symbols);
+        let __sym0 = __pop_Variant65(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
-        let __nt = super::__action1494::<>(__sym0, __sym1, __sym2);
-        __symbols.push((__start, __Symbol::Variant63(__nt), __end));
+        let __nt = super::__action1495::<>(__sym0, __sym1, __sym2);
+        __symbols.push((__start, __Symbol::Variant65(__nt), __end));
         (3, 184)
     }
     pub(crate) fn __reduce498<
@@ -25008,11 +25030,11 @@ mod __parse__Top {
     ) -> (usize, usize)
     {
         // OneOrMore<MatchKeywordEntry> = MatchKeywordEntry => ActionFn(306);
-        let __sym0 = __pop_Variant69(__symbols);
+        let __sym0 = __pop_Variant71(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
         let __nt = super::__action306::<>(__sym0);
-        __symbols.push((__start, __Symbol::Variant72(__nt), __end));
+        __symbols.push((__start, __Symbol::Variant74(__nt), __end));
         (1, 185)
     }
     pub(crate) fn __reduce499<
@@ -25024,13 +25046,13 @@ mod __parse__Top {
     {
         // OneOrMore<MatchKeywordEntry> = OneOrMore<MatchKeywordEntry>, ",", MatchKeywordEntry => ActionFn(307);
         assert!(__symbols.len() >= 3);
-        let __sym2 = __pop_Variant69(__symbols);
+        let __sym2 = __pop_Variant71(__symbols);
         let __sym1 = __pop_Variant0(__symbols);
-        let __sym0 = __pop_Variant72(__symbols);
+        let __sym0 = __pop_Variant74(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
         let __nt = super::__action307::<>(__sym0, __sym1, __sym2);
-        __symbols.push((__start, __Symbol::Variant72(__nt), __end));
+        __symbols.push((__start, __Symbol::Variant74(__nt), __end));
         (3, 185)
     }
     pub(crate) fn __reduce500<
@@ -25041,11 +25063,11 @@ mod __parse__Top {
     ) -> (usize, usize)
     {
         // OneOrMore<MatchMappingEntry> = MatchMappingEntry => ActionFn(310);
-        let __sym0 = __pop_Variant70(__symbols);
+        let __sym0 = __pop_Variant72(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
         let __nt = super::__action310::<>(__sym0);
-        __symbols.push((__start, __Symbol::Variant73(__nt), __end));
+        __symbols.push((__start, __Symbol::Variant75(__nt), __end));
         (1, 186)
     }
     pub(crate) fn __reduce501<
@@ -25057,13 +25079,13 @@ mod __parse__Top {
     {
         // OneOrMore<MatchMappingEntry> = OneOrMore<MatchMappingEntry>, ",", MatchMappingEntry => ActionFn(311);
         assert!(__symbols.len() >= 3);
-        let __sym2 = __pop_Variant70(__symbols);
+        let __sym2 = __pop_Variant72(__symbols);
         let __sym1 = __pop_Variant0(__symbols);
-        let __sym0 = __pop_Variant73(__symbols);
+        let __sym0 = __pop_Variant75(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
         let __nt = super::__action311::<>(__sym0, __sym1, __sym2);
-        __symbols.push((__start, __Symbol::Variant73(__nt), __end));
+        __symbols.push((__start, __Symbol::Variant75(__nt), __end));
         (3, 186)
     }
     pub(crate) fn __reduce502<
@@ -25078,7 +25100,7 @@ mod __parse__Top {
         let __start = __sym0.0;
         let __end = __sym0.2;
         let __nt = super::__action444::<>(__sym0);
-        __symbols.push((__start, __Symbol::Variant74(__nt), __end));
+        __symbols.push((__start, __Symbol::Variant76(__nt), __end));
         (1, 187)
     }
     pub(crate) fn __reduce503<
@@ -25092,11 +25114,11 @@ mod __parse__Top {
         assert!(__symbols.len() >= 3);
         let __sym2 = __pop_Variant11(__symbols);
         let __sym1 = __pop_Variant0(__symbols);
-        let __sym0 = __pop_Variant74(__symbols);
+        let __sym0 = __pop_Variant76(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
         let __nt = super::__action445::<>(__sym0, __sym1, __sym2);
-        __symbols.push((__start, __Symbol::Variant74(__nt), __end));
+        __symbols.push((__start, __Symbol::Variant76(__nt), __end));
         (3, 187)
     }
     pub(crate) fn __reduce504<
@@ -25111,7 +25133,7 @@ mod __parse__Top {
         let __start = __sym0.0;
         let __end = __sym0.2;
         let __nt = super::__action433::<>(__sym0);
-        __symbols.push((__start, __Symbol::Variant74(__nt), __end));
+        __symbols.push((__start, __Symbol::Variant76(__nt), __end));
         (1, 188)
     }
     pub(crate) fn __reduce505<
@@ -25125,11 +25147,11 @@ mod __parse__Top {
         assert!(__symbols.len() >= 3);
         let __sym2 = __pop_Variant11(__symbols);
         let __sym1 = __pop_Variant0(__symbols);
-        let __sym0 = __pop_Variant74(__symbols);
+        let __sym0 = __pop_Variant76(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
         let __nt = super::__action434::<>(__sym0, __sym1, __sym2);
-        __symbols.push((__start, __Symbol::Variant74(__nt), __end));
+        __symbols.push((__start, __Symbol::Variant76(__nt), __end));
         (3, 188)
     }
     pub(crate) fn __reduce506<
@@ -25286,11 +25308,11 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // OrPattern = TwoOrMore<ClosedPattern, "|"> => ActionFn(1285);
+        // OrPattern = TwoOrMore<ClosedPattern, "|"> => ActionFn(1286);
         let __sym0 = __pop_Variant50(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action1285::<>(__sym0);
+        let __nt = super::__action1286::<>(__sym0);
         __symbols.push((__start, __Symbol::Variant33(__nt), __end));
         (1, 193)
     }
@@ -25301,13 +25323,13 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // OrTest<"all"> = (<AndTest<"all">> "or")+, AndTest<"all"> => ActionFn(1286);
+        // OrTest<"all"> = (<AndTest<"all">> "or")+, AndTest<"all"> => ActionFn(1287);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant15(__symbols);
         let __sym0 = __pop_Variant17(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action1286::<>(__sym0, __sym1);
+        let __nt = super::__action1287::<>(__sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant15(__nt), __end));
         (2, 194)
     }
@@ -25333,13 +25355,13 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // OrTest<"no-withitems"> = (<AndTest<"all">> "or")+, AndTest<"all"> => ActionFn(1287);
+        // OrTest<"no-withitems"> = (<AndTest<"all">> "or")+, AndTest<"all"> => ActionFn(1288);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant15(__symbols);
         let __sym0 = __pop_Variant17(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action1287::<>(__sym0, __sym1);
+        let __nt = super::__action1288::<>(__sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant15(__nt), __end));
         (2, 195)
     }
@@ -25366,7 +25388,7 @@ mod __parse__Top {
     ) -> (usize, usize)
     {
         // ParameterDef<TypedParameter> = TypedParameter => ActionFn(451);
-        let __sym0 = __pop_Variant81(__symbols);
+        let __sym0 = __pop_Variant83(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
         let __nt = super::__action451::<>(__sym0);
@@ -25384,7 +25406,7 @@ mod __parse__Top {
         assert!(__symbols.len() >= 3);
         let __sym2 = __pop_Variant15(__symbols);
         let __sym1 = __pop_Variant0(__symbols);
-        let __sym0 = __pop_Variant81(__symbols);
+        let __sym0 = __pop_Variant83(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
         let __nt = super::__action452::<>(__sym0, __sym1, __sym2);
@@ -25399,7 +25421,7 @@ mod __parse__Top {
     ) -> (usize, usize)
     {
         // ParameterDef<UntypedParameter> = UntypedParameter => ActionFn(440);
-        let __sym0 = __pop_Variant81(__symbols);
+        let __sym0 = __pop_Variant83(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
         let __nt = super::__action440::<>(__sym0);
@@ -25417,7 +25439,7 @@ mod __parse__Top {
         assert!(__symbols.len() >= 3);
         let __sym2 = __pop_Variant15(__symbols);
         let __sym1 = __pop_Variant0(__symbols);
-        let __sym0 = __pop_Variant81(__symbols);
+        let __sym0 = __pop_Variant83(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
         let __nt = super::__action441::<>(__sym0, __sym1, __sym2);
@@ -25432,11 +25454,11 @@ mod __parse__Top {
     ) -> (usize, usize)
     {
         // ParameterDefs<TypedParameter> = OneOrMore<ParameterDef<TypedParameter>> => ActionFn(398);
-        let __sym0 = __pop_Variant74(__symbols);
+        let __sym0 = __pop_Variant76(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
         let __nt = super::__action398::<>(__sym0);
-        __symbols.push((__start, __Symbol::Variant75(__nt), __end));
+        __symbols.push((__start, __Symbol::Variant77(__nt), __end));
         (1, 198)
     }
     pub(crate) fn __reduce525<
@@ -25450,11 +25472,11 @@ mod __parse__Top {
         assert!(__symbols.len() >= 3);
         let __sym2 = __pop_Variant0(__symbols);
         let __sym1 = __pop_Variant0(__symbols);
-        let __sym0 = __pop_Variant74(__symbols);
+        let __sym0 = __pop_Variant76(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
         let __nt = super::__action658::<>(__sym0, __sym1, __sym2);
-        __symbols.push((__start, __Symbol::Variant75(__nt), __end));
+        __symbols.push((__start, __Symbol::Variant77(__nt), __end));
         (3, 198)
     }
     pub(crate) fn __reduce526<
@@ -25469,11 +25491,11 @@ mod __parse__Top {
         let __sym3 = __pop_Variant12(__symbols);
         let __sym2 = __pop_Variant0(__symbols);
         let __sym1 = __pop_Variant0(__symbols);
-        let __sym0 = __pop_Variant74(__symbols);
+        let __sym0 = __pop_Variant76(__symbols);
         let __start = __sym0.0;
         let __end = __sym3.2;
         let __nt = super::__action659::<>(__sym0, __sym1, __sym2, __sym3);
-        __symbols.push((__start, __Symbol::Variant75(__nt), __end));
+        __symbols.push((__start, __Symbol::Variant77(__nt), __end));
         (4, 198)
     }
     pub(crate) fn __reduce527<
@@ -25484,11 +25506,11 @@ mod __parse__Top {
     ) -> (usize, usize)
     {
         // ParameterDefs<UntypedParameter> = OneOrMore<ParameterDef<UntypedParameter>> => ActionFn(406);
-        let __sym0 = __pop_Variant74(__symbols);
+        let __sym0 = __pop_Variant76(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
         let __nt = super::__action406::<>(__sym0);
-        __symbols.push((__start, __Symbol::Variant75(__nt), __end));
+        __symbols.push((__start, __Symbol::Variant77(__nt), __end));
         (1, 199)
     }
     pub(crate) fn __reduce528<
@@ -25502,11 +25524,11 @@ mod __parse__Top {
         assert!(__symbols.len() >= 3);
         let __sym2 = __pop_Variant0(__symbols);
         let __sym1 = __pop_Variant0(__symbols);
-        let __sym0 = __pop_Variant74(__symbols);
+        let __sym0 = __pop_Variant76(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
         let __nt = super::__action666::<>(__sym0, __sym1, __sym2);
-        __symbols.push((__start, __Symbol::Variant75(__nt), __end));
+        __symbols.push((__start, __Symbol::Variant77(__nt), __end));
         (3, 199)
     }
     pub(crate) fn __reduce529<
@@ -25521,11 +25543,11 @@ mod __parse__Top {
         let __sym3 = __pop_Variant12(__symbols);
         let __sym2 = __pop_Variant0(__symbols);
         let __sym1 = __pop_Variant0(__symbols);
-        let __sym0 = __pop_Variant74(__symbols);
+        let __sym0 = __pop_Variant76(__symbols);
         let __start = __sym0.0;
         let __end = __sym3.2;
         let __nt = super::__action667::<>(__sym0, __sym1, __sym2, __sym3);
-        __symbols.push((__start, __Symbol::Variant75(__nt), __end));
+        __symbols.push((__start, __Symbol::Variant77(__nt), __end));
         (4, 199)
     }
     pub(crate) fn __reduce606<
@@ -25535,13 +25557,13 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // ParameterList<TypedParameter, StarTypedParameter> = KwargParameter<TypedParameter>, "," => ActionFn(1324);
+        // ParameterList<TypedParameter, StarTypedParameter> = KwargParameter<TypedParameter>, "," => ActionFn(1325);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant9(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action1324::<>(__sym0, __sym1);
+        let __nt = super::__action1325::<>(__sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant44(__nt), __end));
         (2, 200)
     }
@@ -25552,11 +25574,11 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // ParameterList<TypedParameter, StarTypedParameter> = KwargParameter<TypedParameter> => ActionFn(1325);
+        // ParameterList<TypedParameter, StarTypedParameter> = KwargParameter<TypedParameter> => ActionFn(1326);
         let __sym0 = __pop_Variant9(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action1325::<>(__sym0);
+        let __nt = super::__action1326::<>(__sym0);
         __symbols.push((__start, __Symbol::Variant44(__nt), __end));
         (1, 200)
     }
@@ -25567,13 +25589,13 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // ParameterList<UntypedParameter, UntypedParameter> = KwargParameter<UntypedParameter>, "," => ActionFn(1362);
+        // ParameterList<UntypedParameter, UntypedParameter> = KwargParameter<UntypedParameter>, "," => ActionFn(1363);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant9(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action1362::<>(__sym0, __sym1);
+        let __nt = super::__action1363::<>(__sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant44(__nt), __end));
         (2, 201)
     }
@@ -25584,11 +25606,11 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // ParameterList<UntypedParameter, UntypedParameter> = KwargParameter<UntypedParameter> => ActionFn(1363);
+        // ParameterList<UntypedParameter, UntypedParameter> = KwargParameter<UntypedParameter> => ActionFn(1364);
         let __sym0 = __pop_Variant9(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action1363::<>(__sym0);
+        let __nt = super::__action1364::<>(__sym0);
         __symbols.push((__start, __Symbol::Variant44(__nt), __end));
         (1, 201)
     }
@@ -25628,11 +25650,11 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // PassStatement = "pass" => ActionFn(1365);
+        // PassStatement = "pass" => ActionFn(1366);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action1365::<>(__sym0);
+        let __nt = super::__action1366::<>(__sym0);
         __symbols.push((__start, __Symbol::Variant35(__nt), __end));
         (1, 206)
     }
@@ -25678,7 +25700,7 @@ mod __parse__Top {
         let __start = __sym0.0;
         let __end = __sym0.2;
         let __nt = super::__action381::<>(__sym0);
-        __symbols.push((__start, __Symbol::Variant76(__nt), __end));
+        __symbols.push((__start, __Symbol::Variant78(__nt), __end));
         (1, 208)
     }
     pub(crate) fn __reduce710<
@@ -25692,7 +25714,7 @@ mod __parse__Top {
         let __start = __lookahead_start.cloned().or_else(|| __symbols.last().map(|s| s.2.clone())).unwrap_or_default();
         let __end = __start.clone();
         let __nt = super::__action382::<>(&__start, &__end);
-        __symbols.push((__start, __Symbol::Variant76(__nt), __end));
+        __symbols.push((__start, __Symbol::Variant78(__nt), __end));
         (0, 208)
     }
     pub(crate) fn __reduce711<
@@ -25702,13 +25724,13 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // Patterns = Pattern, "," => ActionFn(1366);
+        // Patterns = Pattern, "," => ActionFn(1367);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant33(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action1366::<>(__sym0, __sym1);
+        let __nt = super::__action1367::<>(__sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant33(__nt), __end));
         (2, 209)
     }
@@ -25719,13 +25741,13 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // Patterns = TwoOrMore<Pattern, ",">, "," => ActionFn(1367);
+        // Patterns = TwoOrMore<Pattern, ",">, "," => ActionFn(1368);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant50(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action1367::<>(__sym0, __sym1);
+        let __nt = super::__action1368::<>(__sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant33(__nt), __end));
         (2, 209)
     }
@@ -25736,11 +25758,11 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // Patterns = TwoOrMore<Pattern, ","> => ActionFn(1368);
+        // Patterns = TwoOrMore<Pattern, ","> => ActionFn(1369);
         let __sym0 = __pop_Variant50(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action1368::<>(__sym0);
+        let __nt = super::__action1369::<>(__sym0);
         __symbols.push((__start, __Symbol::Variant33(__nt), __end));
         (1, 209)
     }
@@ -25766,14 +25788,14 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // Power<"all"> = AtomExpr<"all">, "**", Factor<"all"> => ActionFn(1369);
+        // Power<"all"> = AtomExpr<"all">, "**", Factor<"all"> => ActionFn(1370);
         assert!(__symbols.len() >= 3);
         let __sym2 = __pop_Variant15(__symbols);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant15(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
-        let __nt = super::__action1369::<>(__sym0, __sym1, __sym2);
+        let __nt = super::__action1370::<>(__sym0, __sym1, __sym2);
         __symbols.push((__start, __Symbol::Variant15(__nt), __end));
         (3, 210)
     }
@@ -25799,14 +25821,14 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // Power<"no-withitems"> = AtomExpr<"all">, "**", Factor<"all"> => ActionFn(1370);
+        // Power<"no-withitems"> = AtomExpr<"all">, "**", Factor<"all"> => ActionFn(1371);
         assert!(__symbols.len() >= 3);
         let __sym2 = __pop_Variant15(__symbols);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant15(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
-        let __nt = super::__action1370::<>(__sym0, __sym1, __sym2);
+        let __nt = super::__action1371::<>(__sym0, __sym1, __sym2);
         __symbols.push((__start, __Symbol::Variant15(__nt), __end));
         (3, 211)
     }
@@ -25956,11 +25978,11 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // RaiseStatement = "raise" => ActionFn(1371);
+        // RaiseStatement = "raise" => ActionFn(1372);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action1371::<>(__sym0);
+        let __nt = super::__action1372::<>(__sym0);
         __symbols.push((__start, __Symbol::Variant35(__nt), __end));
         (1, 213)
     }
@@ -25971,7 +25993,7 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // RaiseStatement = "raise", Test<"all">, "from", Test<"all"> => ActionFn(1372);
+        // RaiseStatement = "raise", Test<"all">, "from", Test<"all"> => ActionFn(1373);
         assert!(__symbols.len() >= 4);
         let __sym3 = __pop_Variant15(__symbols);
         let __sym2 = __pop_Variant0(__symbols);
@@ -25979,7 +26001,7 @@ mod __parse__Top {
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym3.2;
-        let __nt = super::__action1372::<>(__sym0, __sym1, __sym2, __sym3);
+        let __nt = super::__action1373::<>(__sym0, __sym1, __sym2, __sym3);
         __symbols.push((__start, __Symbol::Variant35(__nt), __end));
         (4, 213)
     }
@@ -25990,13 +26012,13 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // RaiseStatement = "raise", Test<"all"> => ActionFn(1373);
+        // RaiseStatement = "raise", Test<"all"> => ActionFn(1374);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant15(__symbols);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action1373::<>(__sym0, __sym1);
+        let __nt = super::__action1374::<>(__sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant35(__nt), __end));
         (2, 213)
     }
@@ -26007,14 +26029,14 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // SequencePattern = "(", Pattern, ")" => ActionFn(1374);
+        // SequencePattern = "(", Pattern, ")" => ActionFn(1375);
         assert!(__symbols.len() >= 3);
         let __sym2 = __pop_Variant0(__symbols);
         let __sym1 = __pop_Variant33(__symbols);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
-        let __nt = super::__action1374::<>(__sym0, __sym1, __sym2);
+        let __nt = super::__action1375::<>(__sym0, __sym1, __sym2);
         __symbols.push((__start, __Symbol::Variant33(__nt), __end));
         (3, 214)
     }
@@ -26025,13 +26047,13 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // SequencePattern = "(", ")" => ActionFn(1375);
+        // SequencePattern = "(", ")" => ActionFn(1376);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action1375::<>(__sym0, __sym1);
+        let __nt = super::__action1376::<>(__sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant33(__nt), __end));
         (2, 214)
     }
@@ -26042,7 +26064,7 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // SequencePattern = "(", Pattern, ",", ")" => ActionFn(1376);
+        // SequencePattern = "(", Pattern, ",", ")" => ActionFn(1377);
         assert!(__symbols.len() >= 4);
         let __sym3 = __pop_Variant0(__symbols);
         let __sym2 = __pop_Variant0(__symbols);
@@ -26050,7 +26072,7 @@ mod __parse__Top {
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym3.2;
-        let __nt = super::__action1376::<>(__sym0, __sym1, __sym2, __sym3);
+        let __nt = super::__action1377::<>(__sym0, __sym1, __sym2, __sym3);
         __symbols.push((__start, __Symbol::Variant33(__nt), __end));
         (4, 214)
     }
@@ -26061,7 +26083,7 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // SequencePattern = "(", (<Pattern> ",")+, Pattern, ",", ")" => ActionFn(1377);
+        // SequencePattern = "(", (<Pattern> ",")+, Pattern, ",", ")" => ActionFn(1378);
         assert!(__symbols.len() >= 5);
         let __sym4 = __pop_Variant0(__symbols);
         let __sym3 = __pop_Variant0(__symbols);
@@ -26070,7 +26092,7 @@ mod __parse__Top {
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym4.2;
-        let __nt = super::__action1377::<>(__sym0, __sym1, __sym2, __sym3, __sym4);
+        let __nt = super::__action1378::<>(__sym0, __sym1, __sym2, __sym3, __sym4);
         __symbols.push((__start, __Symbol::Variant33(__nt), __end));
         (5, 214)
     }
@@ -26081,7 +26103,7 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // SequencePattern = "(", (<Pattern> ",")+, Pattern, ")" => ActionFn(1378);
+        // SequencePattern = "(", (<Pattern> ",")+, Pattern, ")" => ActionFn(1379);
         assert!(__symbols.len() >= 4);
         let __sym3 = __pop_Variant0(__symbols);
         let __sym2 = __pop_Variant33(__symbols);
@@ -26089,7 +26111,7 @@ mod __parse__Top {
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym3.2;
-        let __nt = super::__action1378::<>(__sym0, __sym1, __sym2, __sym3);
+        let __nt = super::__action1379::<>(__sym0, __sym1, __sym2, __sym3);
         __symbols.push((__start, __Symbol::Variant33(__nt), __end));
         (4, 214)
     }
@@ -26100,14 +26122,14 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // SequencePattern = "[", Pattern, "]" => ActionFn(1461);
+        // SequencePattern = "[", Pattern, "]" => ActionFn(1462);
         assert!(__symbols.len() >= 3);
         let __sym2 = __pop_Variant0(__symbols);
         let __sym1 = __pop_Variant33(__symbols);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
-        let __nt = super::__action1461::<>(__sym0, __sym1, __sym2);
+        let __nt = super::__action1462::<>(__sym0, __sym1, __sym2);
         __symbols.push((__start, __Symbol::Variant33(__nt), __end));
         (3, 214)
     }
@@ -26118,13 +26140,13 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // SequencePattern = "[", "]" => ActionFn(1462);
+        // SequencePattern = "[", "]" => ActionFn(1463);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action1462::<>(__sym0, __sym1);
+        let __nt = super::__action1463::<>(__sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant33(__nt), __end));
         (2, 214)
     }
@@ -26135,7 +26157,7 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // SequencePattern = "[", (<Pattern> ",")+, Pattern, "]" => ActionFn(1463);
+        // SequencePattern = "[", (<Pattern> ",")+, Pattern, "]" => ActionFn(1464);
         assert!(__symbols.len() >= 4);
         let __sym3 = __pop_Variant0(__symbols);
         let __sym2 = __pop_Variant33(__symbols);
@@ -26143,7 +26165,7 @@ mod __parse__Top {
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym3.2;
-        let __nt = super::__action1463::<>(__sym0, __sym1, __sym2, __sym3);
+        let __nt = super::__action1464::<>(__sym0, __sym1, __sym2, __sym3);
         __symbols.push((__start, __Symbol::Variant33(__nt), __end));
         (4, 214)
     }
@@ -26154,14 +26176,14 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // SequencePattern = "[", (<Pattern> ",")+, "]" => ActionFn(1464);
+        // SequencePattern = "[", (<Pattern> ",")+, "]" => ActionFn(1465);
         assert!(__symbols.len() >= 3);
         let __sym2 = __pop_Variant0(__symbols);
         let __sym1 = __pop_Variant34(__symbols);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
-        let __nt = super::__action1464::<>(__sym0, __sym1, __sym2);
+        let __nt = super::__action1465::<>(__sym0, __sym1, __sym2);
         __symbols.push((__start, __Symbol::Variant33(__nt), __end));
         (3, 214)
     }
@@ -26204,14 +26226,14 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // ShiftExpression<"all"> = ShiftExpression<"all">, ShiftOp, ArithmeticExpression<"all"> => ActionFn(1380);
+        // ShiftExpression<"all"> = ShiftExpression<"all">, ShiftOp, ArithmeticExpression<"all"> => ActionFn(1381);
         assert!(__symbols.len() >= 3);
         let __sym2 = __pop_Variant15(__symbols);
         let __sym1 = __pop_Variant47(__symbols);
         let __sym0 = __pop_Variant15(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
-        let __nt = super::__action1380::<>(__sym0, __sym1, __sym2);
+        let __nt = super::__action1381::<>(__sym0, __sym1, __sym2);
         __symbols.push((__start, __Symbol::Variant15(__nt), __end));
         (3, 216)
     }
@@ -26237,14 +26259,14 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // ShiftExpression<"no-withitems"> = ShiftExpression<"all">, ShiftOp, ArithmeticExpression<"all"> => ActionFn(1381);
+        // ShiftExpression<"no-withitems"> = ShiftExpression<"all">, ShiftOp, ArithmeticExpression<"all"> => ActionFn(1382);
         assert!(__symbols.len() >= 3);
         let __sym2 = __pop_Variant15(__symbols);
         let __sym1 = __pop_Variant47(__symbols);
         let __sym0 = __pop_Variant15(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
-        let __nt = super::__action1381::<>(__sym0, __sym1, __sym2);
+        let __nt = super::__action1382::<>(__sym0, __sym1, __sym2);
         __symbols.push((__start, __Symbol::Variant15(__nt), __end));
         (3, 217)
     }
@@ -26300,7 +26322,7 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // SingleForComprehension = "async", "for", ExpressionList, "in", OrTest<"all"> => ActionFn(1467);
+        // SingleForComprehension = "async", "for", ExpressionList, "in", OrTest<"all"> => ActionFn(1468);
         assert!(__symbols.len() >= 5);
         let __sym4 = __pop_Variant15(__symbols);
         let __sym3 = __pop_Variant0(__symbols);
@@ -26309,8 +26331,8 @@ mod __parse__Top {
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym4.2;
-        let __nt = super::__action1467::<>(__sym0, __sym1, __sym2, __sym3, __sym4);
-        __symbols.push((__start, __Symbol::Variant77(__nt), __end));
+        let __nt = super::__action1468::<>(__sym0, __sym1, __sym2, __sym3, __sym4);
+        __symbols.push((__start, __Symbol::Variant79(__nt), __end));
         (5, 219)
     }
     pub(crate) fn __reduce747<
@@ -26320,7 +26342,7 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // SingleForComprehension = "async", "for", ExpressionList, "in", OrTest<"all">, ComprehensionIf+ => ActionFn(1468);
+        // SingleForComprehension = "async", "for", ExpressionList, "in", OrTest<"all">, ComprehensionIf+ => ActionFn(1469);
         assert!(__symbols.len() >= 6);
         let __sym5 = __pop_Variant17(__symbols);
         let __sym4 = __pop_Variant15(__symbols);
@@ -26330,8 +26352,8 @@ mod __parse__Top {
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym5.2;
-        let __nt = super::__action1468::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5);
-        __symbols.push((__start, __Symbol::Variant77(__nt), __end));
+        let __nt = super::__action1469::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5);
+        __symbols.push((__start, __Symbol::Variant79(__nt), __end));
         (6, 219)
     }
     pub(crate) fn __reduce748<
@@ -26341,7 +26363,7 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // SingleForComprehension = "for", ExpressionList, "in", OrTest<"all"> => ActionFn(1469);
+        // SingleForComprehension = "for", ExpressionList, "in", OrTest<"all"> => ActionFn(1470);
         assert!(__symbols.len() >= 4);
         let __sym3 = __pop_Variant15(__symbols);
         let __sym2 = __pop_Variant0(__symbols);
@@ -26349,8 +26371,8 @@ mod __parse__Top {
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym3.2;
-        let __nt = super::__action1469::<>(__sym0, __sym1, __sym2, __sym3);
-        __symbols.push((__start, __Symbol::Variant77(__nt), __end));
+        let __nt = super::__action1470::<>(__sym0, __sym1, __sym2, __sym3);
+        __symbols.push((__start, __Symbol::Variant79(__nt), __end));
         (4, 219)
     }
     pub(crate) fn __reduce749<
@@ -26360,7 +26382,7 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // SingleForComprehension = "for", ExpressionList, "in", OrTest<"all">, ComprehensionIf+ => ActionFn(1470);
+        // SingleForComprehension = "for", ExpressionList, "in", OrTest<"all">, ComprehensionIf+ => ActionFn(1471);
         assert!(__symbols.len() >= 5);
         let __sym4 = __pop_Variant17(__symbols);
         let __sym3 = __pop_Variant15(__symbols);
@@ -26369,8 +26391,8 @@ mod __parse__Top {
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym4.2;
-        let __nt = super::__action1470::<>(__sym0, __sym1, __sym2, __sym3, __sym4);
-        __symbols.push((__start, __Symbol::Variant77(__nt), __end));
+        let __nt = super::__action1471::<>(__sym0, __sym1, __sym2, __sym3, __sym4);
+        __symbols.push((__start, __Symbol::Variant79(__nt), __end));
         (5, 219)
     }
     pub(crate) fn __reduce750<
@@ -26381,11 +26403,11 @@ mod __parse__Top {
     ) -> (usize, usize)
     {
         // SingleForComprehension+ = SingleForComprehension => ActionFn(230);
-        let __sym0 = __pop_Variant77(__symbols);
+        let __sym0 = __pop_Variant79(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
         let __nt = super::__action230::<>(__sym0);
-        __symbols.push((__start, __Symbol::Variant78(__nt), __end));
+        __symbols.push((__start, __Symbol::Variant80(__nt), __end));
         (1, 220)
     }
     pub(crate) fn __reduce751<
@@ -26397,12 +26419,12 @@ mod __parse__Top {
     {
         // SingleForComprehension+ = SingleForComprehension+, SingleForComprehension => ActionFn(231);
         assert!(__symbols.len() >= 2);
-        let __sym1 = __pop_Variant77(__symbols);
-        let __sym0 = __pop_Variant78(__symbols);
+        let __sym1 = __pop_Variant79(__symbols);
+        let __sym0 = __pop_Variant80(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
         let __nt = super::__action231::<>(__sym0, __sym1);
-        __symbols.push((__start, __Symbol::Variant78(__nt), __end));
+        __symbols.push((__start, __Symbol::Variant80(__nt), __end));
         (2, 220)
     }
     pub(crate) fn __reduce752<
@@ -26412,14 +26434,14 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // SliceOp = ":", Test<"all"> => ActionFn(1627);
+        // SliceOp = ":", Test<"all"> => ActionFn(1628);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant15(__symbols);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action1627::<>(__sym0, __sym1);
-        __symbols.push((__start, __Symbol::Variant79(__nt), __end));
+        let __nt = super::__action1628::<>(__sym0, __sym1);
+        __symbols.push((__start, __Symbol::Variant81(__nt), __end));
         (2, 221)
     }
     pub(crate) fn __reduce753<
@@ -26429,12 +26451,12 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // SliceOp = ":" => ActionFn(1628);
+        // SliceOp = ":" => ActionFn(1629);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action1628::<>(__sym0);
-        __symbols.push((__start, __Symbol::Variant79(__nt), __end));
+        let __nt = super::__action1629::<>(__sym0);
+        __symbols.push((__start, __Symbol::Variant81(__nt), __end));
         (1, 221)
     }
     pub(crate) fn __reduce754<
@@ -26445,11 +26467,11 @@ mod __parse__Top {
     ) -> (usize, usize)
     {
         // SliceOp? = SliceOp => ActionFn(242);
-        let __sym0 = __pop_Variant79(__symbols);
+        let __sym0 = __pop_Variant81(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
         let __nt = super::__action242::<>(__sym0);
-        __symbols.push((__start, __Symbol::Variant80(__nt), __end));
+        __symbols.push((__start, __Symbol::Variant82(__nt), __end));
         (1, 222)
     }
     pub(crate) fn __reduce755<
@@ -26463,7 +26485,7 @@ mod __parse__Top {
         let __start = __lookahead_start.cloned().or_else(|| __symbols.last().map(|s| s.2.clone())).unwrap_or_default();
         let __end = __start.clone();
         let __nt = super::__action243::<>(&__start, &__end);
-        __symbols.push((__start, __Symbol::Variant80(__nt), __end));
+        __symbols.push((__start, __Symbol::Variant82(__nt), __end));
         (0, 222)
     }
     pub(crate) fn __reduce756<
@@ -26593,13 +26615,13 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // StarExpr = "*", Expression<"all"> => ActionFn(1384);
+        // StarExpr = "*", Expression<"all"> => ActionFn(1385);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant15(__symbols);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action1384::<>(__sym0, __sym1);
+        let __nt = super::__action1385::<>(__sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant15(__nt), __end));
         (2, 224)
     }
@@ -26610,13 +26632,13 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // StarPattern = "*", Identifier => ActionFn(1385);
+        // StarPattern = "*", Identifier => ActionFn(1386);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant23(__symbols);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action1385::<>(__sym0, __sym1);
+        let __nt = super::__action1386::<>(__sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant33(__nt), __end));
         (2, 225)
     }
@@ -26627,15 +26649,15 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // StarTypedParameter = Identifier, ":", TestOrStarExpr => ActionFn(1386);
+        // StarTypedParameter = Identifier, ":", TestOrStarExpr => ActionFn(1387);
         assert!(__symbols.len() >= 3);
         let __sym2 = __pop_Variant15(__symbols);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant23(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
-        let __nt = super::__action1386::<>(__sym0, __sym1, __sym2);
-        __symbols.push((__start, __Symbol::Variant81(__nt), __end));
+        let __nt = super::__action1387::<>(__sym0, __sym1, __sym2);
+        __symbols.push((__start, __Symbol::Variant83(__nt), __end));
         (3, 226)
     }
     pub(crate) fn __reduce767<
@@ -26645,12 +26667,12 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // StarTypedParameter = Identifier => ActionFn(1387);
+        // StarTypedParameter = Identifier => ActionFn(1388);
         let __sym0 = __pop_Variant23(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action1387::<>(__sym0);
-        __symbols.push((__start, __Symbol::Variant81(__nt), __end));
+        let __nt = super::__action1388::<>(__sym0);
+        __symbols.push((__start, __Symbol::Variant83(__nt), __end));
         (1, 226)
     }
     pub(crate) fn __reduce768<
@@ -26661,11 +26683,11 @@ mod __parse__Top {
     ) -> (usize, usize)
     {
         // StarTypedParameter? = StarTypedParameter => ActionFn(453);
-        let __sym0 = __pop_Variant81(__symbols);
+        let __sym0 = __pop_Variant83(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
         let __nt = super::__action453::<>(__sym0);
-        __symbols.push((__start, __Symbol::Variant82(__nt), __end));
+        __symbols.push((__start, __Symbol::Variant84(__nt), __end));
         (1, 227)
     }
     pub(crate) fn __reduce769<
@@ -26679,7 +26701,7 @@ mod __parse__Top {
         let __start = __lookahead_start.cloned().or_else(|| __symbols.last().map(|s| s.2.clone())).unwrap_or_default();
         let __end = __start.clone();
         let __nt = super::__action454::<>(&__start, &__end);
-        __symbols.push((__start, __Symbol::Variant82(__nt), __end));
+        __symbols.push((__start, __Symbol::Variant84(__nt), __end));
         (0, 227)
     }
     pub(crate) fn __reduce770<
@@ -26697,7 +26719,7 @@ mod __parse__Top {
         let __start = __sym0.0;
         let __end = __sym2.2;
         let __nt = super::__action1130::<>(__sym0, __sym1, __sym2);
-        __symbols.push((__start, __Symbol::Variant83(__nt), __end));
+        __symbols.push((__start, __Symbol::Variant85(__nt), __end));
         (3, 228)
     }
     pub(crate) fn __reduce771<
@@ -26716,7 +26738,7 @@ mod __parse__Top {
         let __start = __sym0.0;
         let __end = __sym3.2;
         let __nt = super::__action1131::<>(__sym0, __sym1, __sym2, __sym3);
-        __symbols.push((__start, __Symbol::Variant83(__nt), __end));
+        __symbols.push((__start, __Symbol::Variant85(__nt), __end));
         (4, 228)
     }
     pub(crate) fn __reduce772<
@@ -26733,7 +26755,7 @@ mod __parse__Top {
         let __start = __sym0.0;
         let __end = __sym1.2;
         let __nt = super::__action1132::<>(__sym0, __sym1);
-        __symbols.push((__start, __Symbol::Variant83(__nt), __end));
+        __symbols.push((__start, __Symbol::Variant85(__nt), __end));
         (2, 228)
     }
     pub(crate) fn __reduce773<
@@ -26751,7 +26773,7 @@ mod __parse__Top {
         let __start = __sym0.0;
         let __end = __sym2.2;
         let __nt = super::__action1133::<>(__sym0, __sym1, __sym2);
-        __symbols.push((__start, __Symbol::Variant83(__nt), __end));
+        __symbols.push((__start, __Symbol::Variant85(__nt), __end));
         (3, 228)
     }
     pub(crate) fn __reduce774<
@@ -26766,7 +26788,7 @@ mod __parse__Top {
         let __start = __sym0.0;
         let __end = __sym0.2;
         let __nt = super::__action11::<>(__sym0);
-        __symbols.push((__start, __Symbol::Variant83(__nt), __end));
+        __symbols.push((__start, __Symbol::Variant85(__nt), __end));
         (1, 228)
     }
     pub(crate) fn __reduce775<
@@ -26779,11 +26801,11 @@ mod __parse__Top {
         // Statements = Statements, CompoundStatement => ActionFn(12);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant35(__symbols);
-        let __sym0 = __pop_Variant83(__symbols);
+        let __sym0 = __pop_Variant85(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
         let __nt = super::__action12::<>(__sym0, __sym1);
-        __symbols.push((__start, __Symbol::Variant83(__nt), __end));
+        __symbols.push((__start, __Symbol::Variant85(__nt), __end));
         (2, 228)
     }
     pub(crate) fn __reduce776<
@@ -26798,11 +26820,11 @@ mod __parse__Top {
         let __sym3 = __pop_Variant0(__symbols);
         let __sym2 = __pop_Variant0(__symbols);
         let __sym1 = __pop_Variant35(__symbols);
-        let __sym0 = __pop_Variant83(__symbols);
+        let __sym0 = __pop_Variant85(__symbols);
         let __start = __sym0.0;
         let __end = __sym3.2;
         let __nt = super::__action1134::<>(__sym0, __sym1, __sym2, __sym3);
-        __symbols.push((__start, __Symbol::Variant83(__nt), __end));
+        __symbols.push((__start, __Symbol::Variant85(__nt), __end));
         (4, 228)
     }
     pub(crate) fn __reduce777<
@@ -26818,11 +26840,11 @@ mod __parse__Top {
         let __sym3 = __pop_Variant0(__symbols);
         let __sym2 = __pop_Variant35(__symbols);
         let __sym1 = __pop_Variant36(__symbols);
-        let __sym0 = __pop_Variant83(__symbols);
+        let __sym0 = __pop_Variant85(__symbols);
         let __start = __sym0.0;
         let __end = __sym4.2;
         let __nt = super::__action1135::<>(__sym0, __sym1, __sym2, __sym3, __sym4);
-        __symbols.push((__start, __Symbol::Variant83(__nt), __end));
+        __symbols.push((__start, __Symbol::Variant85(__nt), __end));
         (5, 228)
     }
     pub(crate) fn __reduce778<
@@ -26836,11 +26858,11 @@ mod __parse__Top {
         assert!(__symbols.len() >= 3);
         let __sym2 = __pop_Variant0(__symbols);
         let __sym1 = __pop_Variant35(__symbols);
-        let __sym0 = __pop_Variant83(__symbols);
+        let __sym0 = __pop_Variant85(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
         let __nt = super::__action1136::<>(__sym0, __sym1, __sym2);
-        __symbols.push((__start, __Symbol::Variant83(__nt), __end));
+        __symbols.push((__start, __Symbol::Variant85(__nt), __end));
         (3, 228)
     }
     pub(crate) fn __reduce779<
@@ -26855,11 +26877,11 @@ mod __parse__Top {
         let __sym3 = __pop_Variant0(__symbols);
         let __sym2 = __pop_Variant35(__symbols);
         let __sym1 = __pop_Variant36(__symbols);
-        let __sym0 = __pop_Variant83(__symbols);
+        let __sym0 = __pop_Variant85(__symbols);
         let __start = __sym0.0;
         let __end = __sym3.2;
         let __nt = super::__action1137::<>(__sym0, __sym1, __sym2, __sym3);
-        __symbols.push((__start, __Symbol::Variant83(__nt), __end));
+        __symbols.push((__start, __Symbol::Variant85(__nt), __end));
         (4, 228)
     }
     pub(crate) fn __reduce780<
@@ -26884,15 +26906,15 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // Subscript = Test<"all">, ":", Test<"all">, SliceOp => ActionFn(1629);
+        // Subscript = Test<"all">, ":", Test<"all">, SliceOp => ActionFn(1630);
         assert!(__symbols.len() >= 4);
-        let __sym3 = __pop_Variant79(__symbols);
+        let __sym3 = __pop_Variant81(__symbols);
         let __sym2 = __pop_Variant15(__symbols);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant15(__symbols);
         let __start = __sym0.0;
         let __end = __sym3.2;
-        let __nt = super::__action1629::<>(__sym0, __sym1, __sym2, __sym3);
+        let __nt = super::__action1630::<>(__sym0, __sym1, __sym2, __sym3);
         __symbols.push((__start, __Symbol::Variant15(__nt), __end));
         (4, 229)
     }
@@ -26903,14 +26925,14 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // Subscript = Test<"all">, ":", SliceOp => ActionFn(1630);
+        // Subscript = Test<"all">, ":", SliceOp => ActionFn(1631);
         assert!(__symbols.len() >= 3);
-        let __sym2 = __pop_Variant79(__symbols);
+        let __sym2 = __pop_Variant81(__symbols);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant15(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
-        let __nt = super::__action1630::<>(__sym0, __sym1, __sym2);
+        let __nt = super::__action1631::<>(__sym0, __sym1, __sym2);
         __symbols.push((__start, __Symbol::Variant15(__nt), __end));
         (3, 229)
     }
@@ -26921,14 +26943,14 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // Subscript = ":", Test<"all">, SliceOp => ActionFn(1631);
+        // Subscript = ":", Test<"all">, SliceOp => ActionFn(1632);
         assert!(__symbols.len() >= 3);
-        let __sym2 = __pop_Variant79(__symbols);
+        let __sym2 = __pop_Variant81(__symbols);
         let __sym1 = __pop_Variant15(__symbols);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
-        let __nt = super::__action1631::<>(__sym0, __sym1, __sym2);
+        let __nt = super::__action1632::<>(__sym0, __sym1, __sym2);
         __symbols.push((__start, __Symbol::Variant15(__nt), __end));
         (3, 229)
     }
@@ -26939,13 +26961,13 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // Subscript = ":", SliceOp => ActionFn(1632);
+        // Subscript = ":", SliceOp => ActionFn(1633);
         assert!(__symbols.len() >= 2);
-        let __sym1 = __pop_Variant79(__symbols);
+        let __sym1 = __pop_Variant81(__symbols);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action1632::<>(__sym0, __sym1);
+        let __nt = super::__action1633::<>(__sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant15(__nt), __end));
         (2, 229)
     }
@@ -26956,14 +26978,14 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // Subscript = Test<"all">, ":", Test<"all"> => ActionFn(1633);
+        // Subscript = Test<"all">, ":", Test<"all"> => ActionFn(1634);
         assert!(__symbols.len() >= 3);
         let __sym2 = __pop_Variant15(__symbols);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant15(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
-        let __nt = super::__action1633::<>(__sym0, __sym1, __sym2);
+        let __nt = super::__action1634::<>(__sym0, __sym1, __sym2);
         __symbols.push((__start, __Symbol::Variant15(__nt), __end));
         (3, 229)
     }
@@ -26974,13 +26996,13 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // Subscript = Test<"all">, ":" => ActionFn(1634);
+        // Subscript = Test<"all">, ":" => ActionFn(1635);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant15(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action1634::<>(__sym0, __sym1);
+        let __nt = super::__action1635::<>(__sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant15(__nt), __end));
         (2, 229)
     }
@@ -26991,13 +27013,13 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // Subscript = ":", Test<"all"> => ActionFn(1635);
+        // Subscript = ":", Test<"all"> => ActionFn(1636);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant15(__symbols);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action1635::<>(__sym0, __sym1);
+        let __nt = super::__action1636::<>(__sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant15(__nt), __end));
         (2, 229)
     }
@@ -27008,11 +27030,11 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // Subscript = ":" => ActionFn(1636);
+        // Subscript = ":" => ActionFn(1637);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action1636::<>(__sym0);
+        let __nt = super::__action1637::<>(__sym0);
         __symbols.push((__start, __Symbol::Variant15(__nt), __end));
         (1, 229)
     }
@@ -27023,11 +27045,11 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // SubscriptList = Subscript => ActionFn(1389);
+        // SubscriptList = Subscript => ActionFn(1390);
         let __sym0 = __pop_Variant15(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action1389::<>(__sym0);
+        let __nt = super::__action1390::<>(__sym0);
         __symbols.push((__start, __Symbol::Variant15(__nt), __end));
         (1, 230)
     }
@@ -27038,13 +27060,13 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // SubscriptList = Subscript, "," => ActionFn(1390);
+        // SubscriptList = Subscript, "," => ActionFn(1391);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant15(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action1390::<>(__sym0, __sym1);
+        let __nt = super::__action1391::<>(__sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant15(__nt), __end));
         (2, 230)
     }
@@ -27055,13 +27077,13 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // SubscriptList = TwoOrMore<Subscript, ",">, "," => ActionFn(1391);
+        // SubscriptList = TwoOrMore<Subscript, ",">, "," => ActionFn(1392);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant31(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action1391::<>(__sym0, __sym1);
+        let __nt = super::__action1392::<>(__sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant15(__nt), __end));
         (2, 230)
     }
@@ -27072,11 +27094,11 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // SubscriptList = TwoOrMore<Subscript, ","> => ActionFn(1392);
+        // SubscriptList = TwoOrMore<Subscript, ","> => ActionFn(1393);
         let __sym0 = __pop_Variant31(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action1392::<>(__sym0);
+        let __nt = super::__action1393::<>(__sym0);
         __symbols.push((__start, __Symbol::Variant15(__nt), __end));
         (1, 230)
     }
@@ -27162,7 +27184,7 @@ mod __parse__Top {
         // Suite = "\n", Indent, Statements, Dedent => ActionFn(9);
         assert!(__symbols.len() >= 4);
         let __sym3 = __pop_Variant0(__symbols);
-        let __sym2 = __pop_Variant83(__symbols);
+        let __sym2 = __pop_Variant85(__symbols);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
@@ -27178,14 +27200,14 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // Term<"all"> = Term<"all">, MulOp, Factor<"all"> => ActionFn(1393);
+        // Term<"all"> = Term<"all">, MulOp, Factor<"all"> => ActionFn(1394);
         assert!(__symbols.len() >= 3);
         let __sym2 = __pop_Variant15(__symbols);
         let __sym1 = __pop_Variant47(__symbols);
         let __sym0 = __pop_Variant15(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
-        let __nt = super::__action1393::<>(__sym0, __sym1, __sym2);
+        let __nt = super::__action1394::<>(__sym0, __sym1, __sym2);
         __symbols.push((__start, __Symbol::Variant15(__nt), __end));
         (3, 232)
     }
@@ -27211,14 +27233,14 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // Term<"no-withitems"> = Term<"all">, MulOp, Factor<"all"> => ActionFn(1394);
+        // Term<"no-withitems"> = Term<"all">, MulOp, Factor<"all"> => ActionFn(1395);
         assert!(__symbols.len() >= 3);
         let __sym2 = __pop_Variant15(__symbols);
         let __sym1 = __pop_Variant47(__symbols);
         let __sym0 = __pop_Variant15(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
-        let __nt = super::__action1394::<>(__sym0, __sym1, __sym2);
+        let __nt = super::__action1395::<>(__sym0, __sym1, __sym2);
         __symbols.push((__start, __Symbol::Variant15(__nt), __end));
         (3, 233)
     }
@@ -27244,7 +27266,7 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // Test<"all"> = OrTest<"all">, "if", OrTest<"all">, "else", Test<"all"> => ActionFn(1395);
+        // Test<"all"> = OrTest<"all">, "if", OrTest<"all">, "else", Test<"all"> => ActionFn(1396);
         assert!(__symbols.len() >= 5);
         let __sym4 = __pop_Variant15(__symbols);
         let __sym3 = __pop_Variant0(__symbols);
@@ -27253,7 +27275,7 @@ mod __parse__Top {
         let __sym0 = __pop_Variant15(__symbols);
         let __start = __sym0.0;
         let __end = __sym4.2;
-        let __nt = super::__action1395::<>(__sym0, __sym1, __sym2, __sym3, __sym4);
+        let __nt = super::__action1396::<>(__sym0, __sym1, __sym2, __sym3, __sym4);
         __symbols.push((__start, __Symbol::Variant15(__nt), __end));
         (5, 234)
     }
@@ -27323,7 +27345,7 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // Test<"no-withitems"> = OrTest<"all">, "if", OrTest<"all">, "else", Test<"all"> => ActionFn(1396);
+        // Test<"no-withitems"> = OrTest<"all">, "if", OrTest<"all">, "else", Test<"all"> => ActionFn(1397);
         assert!(__symbols.len() >= 5);
         let __sym4 = __pop_Variant15(__symbols);
         let __sym3 = __pop_Variant0(__symbols);
@@ -27332,7 +27354,7 @@ mod __parse__Top {
         let __sym0 = __pop_Variant15(__symbols);
         let __start = __sym0.0;
         let __end = __sym4.2;
-        let __nt = super::__action1396::<>(__sym0, __sym1, __sym2, __sym3, __sym4);
+        let __nt = super::__action1397::<>(__sym0, __sym1, __sym2, __sym3, __sym4);
         __symbols.push((__start, __Symbol::Variant15(__nt), __end));
         (5, 236)
     }
@@ -27388,11 +27410,11 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // TestList? = GenericList<TestOrStarExpr> => ActionFn(1641);
+        // TestList? = GenericList<TestOrStarExpr> => ActionFn(1642);
         let __sym0 = __pop_Variant15(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action1641::<>(__sym0);
+        let __nt = super::__action1642::<>(__sym0);
         __symbols.push((__start, __Symbol::Variant16(__nt), __end));
         (1, 238)
     }
@@ -27417,11 +27439,11 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // TestListOrYieldExpr = GenericList<TestOrStarExpr> => ActionFn(1642);
+        // TestListOrYieldExpr = GenericList<TestOrStarExpr> => ActionFn(1643);
         let __sym0 = __pop_Variant15(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action1642::<>(__sym0);
+        let __nt = super::__action1643::<>(__sym0);
         __symbols.push((__start, __Symbol::Variant15(__nt), __end));
         (1, 239)
     }
@@ -27477,11 +27499,11 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // TestOrStarExprList = GenericList<TestOrStarExpr> => ActionFn(1643);
+        // TestOrStarExprList = GenericList<TestOrStarExpr> => ActionFn(1644);
         let __sym0 = __pop_Variant15(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action1643::<>(__sym0);
+        let __nt = super::__action1644::<>(__sym0);
         __symbols.push((__start, __Symbol::Variant15(__nt), __end));
         (1, 241)
     }
@@ -27522,14 +27544,14 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // Top = StartModule, Program => ActionFn(1397);
+        // Top = StartModule, Program => ActionFn(1398);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant25(__symbols);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action1397::<>(__sym0, __sym1);
-        __symbols.push((__start, __Symbol::Variant84(__nt), __end));
+        let __nt = super::__action1398::<>(__sym0, __sym1);
+        __symbols.push((__start, __Symbol::Variant86(__nt), __end));
         (2, 243)
     }
     pub(crate) fn __reduce821<
@@ -27539,14 +27561,14 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // Top = StartInteractive, Program => ActionFn(1398);
+        // Top = StartInteractive, Program => ActionFn(1399);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant25(__symbols);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action1398::<>(__sym0, __sym1);
-        __symbols.push((__start, __Symbol::Variant84(__nt), __end));
+        let __nt = super::__action1399::<>(__sym0, __sym1);
+        __symbols.push((__start, __Symbol::Variant86(__nt), __end));
         (2, 243)
     }
     pub(crate) fn __reduce822<
@@ -27556,14 +27578,14 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // Top = StartExpression, GenericList<TestOrStarExpr> => ActionFn(1644);
+        // Top = StartExpression, GenericList<TestOrStarExpr> => ActionFn(1645);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant15(__symbols);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action1644::<>(__sym0, __sym1);
-        __symbols.push((__start, __Symbol::Variant84(__nt), __end));
+        let __nt = super::__action1645::<>(__sym0, __sym1);
+        __symbols.push((__start, __Symbol::Variant86(__nt), __end));
         (2, 243)
     }
     pub(crate) fn __reduce823<
@@ -27573,15 +27595,15 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // Top = StartExpression, GenericList<TestOrStarExpr>, ("\n")+ => ActionFn(1645);
+        // Top = StartExpression, GenericList<TestOrStarExpr>, ("\n")+ => ActionFn(1646);
         assert!(__symbols.len() >= 3);
         let __sym2 = __pop_Variant22(__symbols);
         let __sym1 = __pop_Variant15(__symbols);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
-        let __nt = super::__action1645::<>(__sym0, __sym1, __sym2);
-        __symbols.push((__start, __Symbol::Variant84(__nt), __end));
+        let __nt = super::__action1646::<>(__sym0, __sym1, __sym2);
+        __symbols.push((__start, __Symbol::Variant86(__nt), __end));
         (3, 243)
     }
     pub(crate) fn __reduce824<
@@ -27591,7 +27613,7 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // TryStatement = "try", ":", Suite, ExceptClause+, "else", ":", Suite, "finally", ":", Suite => ActionFn(1401);
+        // TryStatement = "try", ":", Suite, ExceptClause+, "else", ":", Suite, "finally", ":", Suite => ActionFn(1402);
         assert!(__symbols.len() >= 10);
         let __sym9 = __pop_Variant25(__symbols);
         let __sym8 = __pop_Variant0(__symbols);
@@ -27599,13 +27621,13 @@ mod __parse__Top {
         let __sym6 = __pop_Variant25(__symbols);
         let __sym5 = __pop_Variant0(__symbols);
         let __sym4 = __pop_Variant0(__symbols);
-        let __sym3 = __pop_Variant60(__symbols);
+        let __sym3 = __pop_Variant62(__symbols);
         let __sym2 = __pop_Variant25(__symbols);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym9.2;
-        let __nt = super::__action1401::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7, __sym8, __sym9);
+        let __nt = super::__action1402::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7, __sym8, __sym9);
         __symbols.push((__start, __Symbol::Variant35(__nt), __end));
         (10, 244)
     }
@@ -27616,18 +27638,18 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // TryStatement = "try", ":", Suite, ExceptClause+, "else", ":", Suite => ActionFn(1402);
+        // TryStatement = "try", ":", Suite, ExceptClause+, "else", ":", Suite => ActionFn(1403);
         assert!(__symbols.len() >= 7);
         let __sym6 = __pop_Variant25(__symbols);
         let __sym5 = __pop_Variant0(__symbols);
         let __sym4 = __pop_Variant0(__symbols);
-        let __sym3 = __pop_Variant60(__symbols);
+        let __sym3 = __pop_Variant62(__symbols);
         let __sym2 = __pop_Variant25(__symbols);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym6.2;
-        let __nt = super::__action1402::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6);
+        let __nt = super::__action1403::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6);
         __symbols.push((__start, __Symbol::Variant35(__nt), __end));
         (7, 244)
     }
@@ -27638,18 +27660,18 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // TryStatement = "try", ":", Suite, ExceptClause+, "finally", ":", Suite => ActionFn(1403);
+        // TryStatement = "try", ":", Suite, ExceptClause+, "finally", ":", Suite => ActionFn(1404);
         assert!(__symbols.len() >= 7);
         let __sym6 = __pop_Variant25(__symbols);
         let __sym5 = __pop_Variant0(__symbols);
         let __sym4 = __pop_Variant0(__symbols);
-        let __sym3 = __pop_Variant60(__symbols);
+        let __sym3 = __pop_Variant62(__symbols);
         let __sym2 = __pop_Variant25(__symbols);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym6.2;
-        let __nt = super::__action1403::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6);
+        let __nt = super::__action1404::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6);
         __symbols.push((__start, __Symbol::Variant35(__nt), __end));
         (7, 244)
     }
@@ -27660,15 +27682,15 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // TryStatement = "try", ":", Suite, ExceptClause+ => ActionFn(1404);
+        // TryStatement = "try", ":", Suite, ExceptClause+ => ActionFn(1405);
         assert!(__symbols.len() >= 4);
-        let __sym3 = __pop_Variant60(__symbols);
+        let __sym3 = __pop_Variant62(__symbols);
         let __sym2 = __pop_Variant25(__symbols);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym3.2;
-        let __nt = super::__action1404::<>(__sym0, __sym1, __sym2, __sym3);
+        let __nt = super::__action1405::<>(__sym0, __sym1, __sym2, __sym3);
         __symbols.push((__start, __Symbol::Variant35(__nt), __end));
         (4, 244)
     }
@@ -27679,7 +27701,7 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // TryStatement = "try", ":", Suite, ExceptStarClause+, "else", ":", Suite, "finally", ":", Suite => ActionFn(1405);
+        // TryStatement = "try", ":", Suite, ExceptStarClause+, "else", ":", Suite, "finally", ":", Suite => ActionFn(1406);
         assert!(__symbols.len() >= 10);
         let __sym9 = __pop_Variant25(__symbols);
         let __sym8 = __pop_Variant0(__symbols);
@@ -27687,13 +27709,13 @@ mod __parse__Top {
         let __sym6 = __pop_Variant25(__symbols);
         let __sym5 = __pop_Variant0(__symbols);
         let __sym4 = __pop_Variant0(__symbols);
-        let __sym3 = __pop_Variant60(__symbols);
+        let __sym3 = __pop_Variant62(__symbols);
         let __sym2 = __pop_Variant25(__symbols);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym9.2;
-        let __nt = super::__action1405::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7, __sym8, __sym9);
+        let __nt = super::__action1406::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6, __sym7, __sym8, __sym9);
         __symbols.push((__start, __Symbol::Variant35(__nt), __end));
         (10, 244)
     }
@@ -27704,18 +27726,18 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // TryStatement = "try", ":", Suite, ExceptStarClause+, "else", ":", Suite => ActionFn(1406);
+        // TryStatement = "try", ":", Suite, ExceptStarClause+, "else", ":", Suite => ActionFn(1407);
         assert!(__symbols.len() >= 7);
         let __sym6 = __pop_Variant25(__symbols);
         let __sym5 = __pop_Variant0(__symbols);
         let __sym4 = __pop_Variant0(__symbols);
-        let __sym3 = __pop_Variant60(__symbols);
+        let __sym3 = __pop_Variant62(__symbols);
         let __sym2 = __pop_Variant25(__symbols);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym6.2;
-        let __nt = super::__action1406::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6);
+        let __nt = super::__action1407::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6);
         __symbols.push((__start, __Symbol::Variant35(__nt), __end));
         (7, 244)
     }
@@ -27726,18 +27748,18 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // TryStatement = "try", ":", Suite, ExceptStarClause+, "finally", ":", Suite => ActionFn(1407);
+        // TryStatement = "try", ":", Suite, ExceptStarClause+, "finally", ":", Suite => ActionFn(1408);
         assert!(__symbols.len() >= 7);
         let __sym6 = __pop_Variant25(__symbols);
         let __sym5 = __pop_Variant0(__symbols);
         let __sym4 = __pop_Variant0(__symbols);
-        let __sym3 = __pop_Variant60(__symbols);
+        let __sym3 = __pop_Variant62(__symbols);
         let __sym2 = __pop_Variant25(__symbols);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym6.2;
-        let __nt = super::__action1407::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6);
+        let __nt = super::__action1408::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6);
         __symbols.push((__start, __Symbol::Variant35(__nt), __end));
         (7, 244)
     }
@@ -27748,15 +27770,15 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // TryStatement = "try", ":", Suite, ExceptStarClause+ => ActionFn(1408);
+        // TryStatement = "try", ":", Suite, ExceptStarClause+ => ActionFn(1409);
         assert!(__symbols.len() >= 4);
-        let __sym3 = __pop_Variant60(__symbols);
+        let __sym3 = __pop_Variant62(__symbols);
         let __sym2 = __pop_Variant25(__symbols);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym3.2;
-        let __nt = super::__action1408::<>(__sym0, __sym1, __sym2, __sym3);
+        let __nt = super::__action1409::<>(__sym0, __sym1, __sym2, __sym3);
         __symbols.push((__start, __Symbol::Variant35(__nt), __end));
         (4, 244)
     }
@@ -27932,15 +27954,15 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // TypedParameter = Identifier, ":", Test<"all"> => ActionFn(1409);
+        // TypedParameter = Identifier, ":", Test<"all"> => ActionFn(1410);
         assert!(__symbols.len() >= 3);
         let __sym2 = __pop_Variant15(__symbols);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant23(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
-        let __nt = super::__action1409::<>(__sym0, __sym1, __sym2);
-        __symbols.push((__start, __Symbol::Variant81(__nt), __end));
+        let __nt = super::__action1410::<>(__sym0, __sym1, __sym2);
+        __symbols.push((__start, __Symbol::Variant83(__nt), __end));
         (3, 249)
     }
     pub(crate) fn __reduce842<
@@ -27950,12 +27972,12 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // TypedParameter = Identifier => ActionFn(1410);
+        // TypedParameter = Identifier => ActionFn(1411);
         let __sym0 = __pop_Variant23(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action1410::<>(__sym0);
-        __symbols.push((__start, __Symbol::Variant81(__nt), __end));
+        let __nt = super::__action1411::<>(__sym0);
+        __symbols.push((__start, __Symbol::Variant83(__nt), __end));
         (1, 249)
     }
     pub(crate) fn __reduce843<
@@ -27966,11 +27988,11 @@ mod __parse__Top {
     ) -> (usize, usize)
     {
         // TypedParameter? = TypedParameter => ActionFn(455);
-        let __sym0 = __pop_Variant81(__symbols);
+        let __sym0 = __pop_Variant83(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
         let __nt = super::__action455::<>(__sym0);
-        __symbols.push((__start, __Symbol::Variant82(__nt), __end));
+        __symbols.push((__start, __Symbol::Variant84(__nt), __end));
         (1, 250)
     }
     pub(crate) fn __reduce844<
@@ -27984,7 +28006,7 @@ mod __parse__Top {
         let __start = __lookahead_start.cloned().or_else(|| __symbols.last().map(|s| s.2.clone())).unwrap_or_default();
         let __end = __start.clone();
         let __nt = super::__action456::<>(&__start, &__end);
-        __symbols.push((__start, __Symbol::Variant82(__nt), __end));
+        __symbols.push((__start, __Symbol::Variant84(__nt), __end));
         (0, 250)
     }
     pub(crate) fn __reduce845<
@@ -27999,7 +28021,7 @@ mod __parse__Top {
         let __start = __sym0.0;
         let __end = __sym0.2;
         let __nt = super::__action189::<>(__sym0);
-        __symbols.push((__start, __Symbol::Variant85(__nt), __end));
+        __symbols.push((__start, __Symbol::Variant87(__nt), __end));
         (1, 251)
     }
     pub(crate) fn __reduce846<
@@ -28014,7 +28036,7 @@ mod __parse__Top {
         let __start = __sym0.0;
         let __end = __sym0.2;
         let __nt = super::__action190::<>(__sym0);
-        __symbols.push((__start, __Symbol::Variant85(__nt), __end));
+        __symbols.push((__start, __Symbol::Variant87(__nt), __end));
         (1, 251)
     }
     pub(crate) fn __reduce847<
@@ -28029,7 +28051,7 @@ mod __parse__Top {
         let __start = __sym0.0;
         let __end = __sym0.2;
         let __nt = super::__action191::<>(__sym0);
-        __symbols.push((__start, __Symbol::Variant85(__nt), __end));
+        __symbols.push((__start, __Symbol::Variant87(__nt), __end));
         (1, 251)
     }
     pub(crate) fn __reduce848<
@@ -28039,12 +28061,12 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // UntypedParameter = Identifier => ActionFn(1411);
+        // UntypedParameter = Identifier => ActionFn(1412);
         let __sym0 = __pop_Variant23(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action1411::<>(__sym0);
-        __symbols.push((__start, __Symbol::Variant81(__nt), __end));
+        let __nt = super::__action1412::<>(__sym0);
+        __symbols.push((__start, __Symbol::Variant83(__nt), __end));
         (1, 252)
     }
     pub(crate) fn __reduce849<
@@ -28055,11 +28077,11 @@ mod __parse__Top {
     ) -> (usize, usize)
     {
         // UntypedParameter? = UntypedParameter => ActionFn(442);
-        let __sym0 = __pop_Variant81(__symbols);
+        let __sym0 = __pop_Variant83(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
         let __nt = super::__action442::<>(__sym0);
-        __symbols.push((__start, __Symbol::Variant82(__nt), __end));
+        __symbols.push((__start, __Symbol::Variant84(__nt), __end));
         (1, 253)
     }
     pub(crate) fn __reduce850<
@@ -28073,7 +28095,7 @@ mod __parse__Top {
         let __start = __lookahead_start.cloned().or_else(|| __symbols.last().map(|s| s.2.clone())).unwrap_or_default();
         let __end = __start.clone();
         let __nt = super::__action443::<>(&__start, &__end);
-        __symbols.push((__start, __Symbol::Variant82(__nt), __end));
+        __symbols.push((__start, __Symbol::Variant84(__nt), __end));
         (0, 253)
     }
     pub(crate) fn __reduce851<
@@ -28083,11 +28105,11 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // ValuePattern = MatchNameOrAttr => ActionFn(1412);
+        // ValuePattern = MatchNameOrAttr => ActionFn(1413);
         let __sym0 = __pop_Variant15(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action1412::<>(__sym0);
+        let __nt = super::__action1413::<>(__sym0);
         __symbols.push((__start, __Symbol::Variant33(__nt), __end));
         (1, 254)
     }
@@ -28139,11 +28161,11 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // WithItem<"all"> = Test<"all"> => ActionFn(1413);
+        // WithItem<"all"> = Test<"all"> => ActionFn(1414);
         let __sym0 = __pop_Variant15(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action1413::<>(__sym0);
+        let __nt = super::__action1414::<>(__sym0);
         __symbols.push((__start, __Symbol::Variant18(__nt), __end));
         (1, 256)
     }
@@ -28154,14 +28176,14 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // WithItem<"all"> = Test<"all">, "as", Expression<"all"> => ActionFn(1414);
+        // WithItem<"all"> = Test<"all">, "as", Expression<"all"> => ActionFn(1415);
         assert!(__symbols.len() >= 3);
         let __sym2 = __pop_Variant15(__symbols);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant15(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
-        let __nt = super::__action1414::<>(__sym0, __sym1, __sym2);
+        let __nt = super::__action1415::<>(__sym0, __sym1, __sym2);
         __symbols.push((__start, __Symbol::Variant18(__nt), __end));
         (3, 256)
     }
@@ -28172,14 +28194,14 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // WithItem<"as"> = Test<"all">, "as", Expression<"all"> => ActionFn(1415);
+        // WithItem<"as"> = Test<"all">, "as", Expression<"all"> => ActionFn(1416);
         assert!(__symbols.len() >= 3);
         let __sym2 = __pop_Variant15(__symbols);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant15(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
-        let __nt = super::__action1415::<>(__sym0, __sym1, __sym2);
+        let __nt = super::__action1416::<>(__sym0, __sym1, __sym2);
         __symbols.push((__start, __Symbol::Variant18(__nt), __end));
         (3, 257)
     }
@@ -28190,11 +28212,11 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // WithItem<"no-withitems"> = Test<"no-withitems"> => ActionFn(1416);
+        // WithItem<"no-withitems"> = Test<"no-withitems"> => ActionFn(1417);
         let __sym0 = __pop_Variant15(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action1416::<>(__sym0);
+        let __nt = super::__action1417::<>(__sym0);
         __symbols.push((__start, __Symbol::Variant18(__nt), __end));
         (1, 258)
     }
@@ -28205,14 +28227,14 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // WithItem<"no-withitems"> = Test<"all">, "as", Expression<"all"> => ActionFn(1417);
+        // WithItem<"no-withitems"> = Test<"all">, "as", Expression<"all"> => ActionFn(1418);
         assert!(__symbols.len() >= 3);
         let __sym2 = __pop_Variant15(__symbols);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant15(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
-        let __nt = super::__action1417::<>(__sym0, __sym1, __sym2);
+        let __nt = super::__action1418::<>(__sym0, __sym1, __sym2);
         __symbols.push((__start, __Symbol::Variant18(__nt), __end));
         (3, 258)
     }
@@ -28223,7 +28245,7 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // WithItems = "(", OneOrMore<Test<"all">>, ",", ")" => ActionFn(1424);
+        // WithItems = "(", OneOrMore<Test<"all">>, ",", ")" => ActionFn(1425);
         assert!(__symbols.len() >= 4);
         let __sym3 = __pop_Variant0(__symbols);
         let __sym2 = __pop_Variant0(__symbols);
@@ -28231,7 +28253,7 @@ mod __parse__Top {
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym3.2;
-        let __nt = super::__action1424::<>(__sym0, __sym1, __sym2, __sym3);
+        let __nt = super::__action1425::<>(__sym0, __sym1, __sym2, __sym3);
         __symbols.push((__start, __Symbol::Variant38(__nt), __end));
         (4, 259)
     }
@@ -28242,14 +28264,14 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // WithItems = "(", OneOrMore<Test<"all">>, ")" => ActionFn(1425);
+        // WithItems = "(", OneOrMore<Test<"all">>, ")" => ActionFn(1426);
         assert!(__symbols.len() >= 3);
         let __sym2 = __pop_Variant0(__symbols);
         let __sym1 = __pop_Variant31(__symbols);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
-        let __nt = super::__action1425::<>(__sym0, __sym1, __sym2);
+        let __nt = super::__action1426::<>(__sym0, __sym1, __sym2);
         __symbols.push((__start, __Symbol::Variant38(__nt), __end));
         (3, 259)
     }
@@ -28260,7 +28282,7 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // WithItems = "(", OneOrMore<Test<"all">>, ",", WithItem<"as">, ",", ")" => ActionFn(1427);
+        // WithItems = "(", OneOrMore<Test<"all">>, ",", WithItem<"as">, ",", ")" => ActionFn(1428);
         assert!(__symbols.len() >= 6);
         let __sym5 = __pop_Variant0(__symbols);
         let __sym4 = __pop_Variant0(__symbols);
@@ -28270,7 +28292,7 @@ mod __parse__Top {
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym5.2;
-        let __nt = super::__action1427::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5);
+        let __nt = super::__action1428::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5);
         __symbols.push((__start, __Symbol::Variant38(__nt), __end));
         (6, 259)
     }
@@ -28281,7 +28303,7 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // WithItems = "(", WithItem<"as">, ",", ")" => ActionFn(1428);
+        // WithItems = "(", WithItem<"as">, ",", ")" => ActionFn(1429);
         assert!(__symbols.len() >= 4);
         let __sym3 = __pop_Variant0(__symbols);
         let __sym2 = __pop_Variant0(__symbols);
@@ -28289,7 +28311,7 @@ mod __parse__Top {
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym3.2;
-        let __nt = super::__action1428::<>(__sym0, __sym1, __sym2, __sym3);
+        let __nt = super::__action1429::<>(__sym0, __sym1, __sym2, __sym3);
         __symbols.push((__start, __Symbol::Variant38(__nt), __end));
         (4, 259)
     }
@@ -28300,7 +28322,7 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // WithItems = "(", OneOrMore<Test<"all">>, ",", WithItem<"as">, ("," <WithItem<"all">>)+, ",", ")" => ActionFn(1429);
+        // WithItems = "(", OneOrMore<Test<"all">>, ",", WithItem<"as">, ("," <WithItem<"all">>)+, ",", ")" => ActionFn(1430);
         assert!(__symbols.len() >= 7);
         let __sym6 = __pop_Variant0(__symbols);
         let __sym5 = __pop_Variant0(__symbols);
@@ -28311,7 +28333,7 @@ mod __parse__Top {
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym6.2;
-        let __nt = super::__action1429::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6);
+        let __nt = super::__action1430::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5, __sym6);
         __symbols.push((__start, __Symbol::Variant38(__nt), __end));
         (7, 259)
     }
@@ -28322,7 +28344,7 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // WithItems = "(", WithItem<"as">, ("," <WithItem<"all">>)+, ",", ")" => ActionFn(1430);
+        // WithItems = "(", WithItem<"as">, ("," <WithItem<"all">>)+, ",", ")" => ActionFn(1431);
         assert!(__symbols.len() >= 5);
         let __sym4 = __pop_Variant0(__symbols);
         let __sym3 = __pop_Variant0(__symbols);
@@ -28331,7 +28353,7 @@ mod __parse__Top {
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym4.2;
-        let __nt = super::__action1430::<>(__sym0, __sym1, __sym2, __sym3, __sym4);
+        let __nt = super::__action1431::<>(__sym0, __sym1, __sym2, __sym3, __sym4);
         __symbols.push((__start, __Symbol::Variant38(__nt), __end));
         (5, 259)
     }
@@ -28342,7 +28364,7 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // WithItems = "(", OneOrMore<Test<"all">>, ",", WithItem<"as">, ")" => ActionFn(1431);
+        // WithItems = "(", OneOrMore<Test<"all">>, ",", WithItem<"as">, ")" => ActionFn(1432);
         assert!(__symbols.len() >= 5);
         let __sym4 = __pop_Variant0(__symbols);
         let __sym3 = __pop_Variant18(__symbols);
@@ -28351,7 +28373,7 @@ mod __parse__Top {
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym4.2;
-        let __nt = super::__action1431::<>(__sym0, __sym1, __sym2, __sym3, __sym4);
+        let __nt = super::__action1432::<>(__sym0, __sym1, __sym2, __sym3, __sym4);
         __symbols.push((__start, __Symbol::Variant38(__nt), __end));
         (5, 259)
     }
@@ -28362,14 +28384,14 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // WithItems = "(", WithItem<"as">, ")" => ActionFn(1432);
+        // WithItems = "(", WithItem<"as">, ")" => ActionFn(1433);
         assert!(__symbols.len() >= 3);
         let __sym2 = __pop_Variant0(__symbols);
         let __sym1 = __pop_Variant18(__symbols);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
-        let __nt = super::__action1432::<>(__sym0, __sym1, __sym2);
+        let __nt = super::__action1433::<>(__sym0, __sym1, __sym2);
         __symbols.push((__start, __Symbol::Variant38(__nt), __end));
         (3, 259)
     }
@@ -28380,7 +28402,7 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // WithItems = "(", OneOrMore<Test<"all">>, ",", WithItem<"as">, ("," <WithItem<"all">>)+, ")" => ActionFn(1433);
+        // WithItems = "(", OneOrMore<Test<"all">>, ",", WithItem<"as">, ("," <WithItem<"all">>)+, ")" => ActionFn(1434);
         assert!(__symbols.len() >= 6);
         let __sym5 = __pop_Variant0(__symbols);
         let __sym4 = __pop_Variant19(__symbols);
@@ -28390,7 +28412,7 @@ mod __parse__Top {
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym5.2;
-        let __nt = super::__action1433::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5);
+        let __nt = super::__action1434::<>(__sym0, __sym1, __sym2, __sym3, __sym4, __sym5);
         __symbols.push((__start, __Symbol::Variant38(__nt), __end));
         (6, 259)
     }
@@ -28401,7 +28423,7 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // WithItems = "(", WithItem<"as">, ("," <WithItem<"all">>)+, ")" => ActionFn(1434);
+        // WithItems = "(", WithItem<"as">, ("," <WithItem<"all">>)+, ")" => ActionFn(1435);
         assert!(__symbols.len() >= 4);
         let __sym3 = __pop_Variant0(__symbols);
         let __sym2 = __pop_Variant19(__symbols);
@@ -28409,7 +28431,7 @@ mod __parse__Top {
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym3.2;
-        let __nt = super::__action1434::<>(__sym0, __sym1, __sym2, __sym3);
+        let __nt = super::__action1435::<>(__sym0, __sym1, __sym2, __sym3);
         __symbols.push((__start, __Symbol::Variant38(__nt), __end));
         (4, 259)
     }
@@ -28452,11 +28474,11 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // WithItemsNoAs = OneOrMore<Test<"all">> => ActionFn(1418);
+        // WithItemsNoAs = OneOrMore<Test<"all">> => ActionFn(1419);
         let __sym0 = __pop_Variant31(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action1418::<>(__sym0);
+        let __nt = super::__action1419::<>(__sym0);
         __symbols.push((__start, __Symbol::Variant38(__nt), __end));
         (1, 260)
     }
@@ -28506,14 +28528,14 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // XorExpression<"all"> = XorExpression<"all">, "^", AndExpression<"all"> => ActionFn(1419);
+        // XorExpression<"all"> = XorExpression<"all">, "^", AndExpression<"all"> => ActionFn(1420);
         assert!(__symbols.len() >= 3);
         let __sym2 = __pop_Variant15(__symbols);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant15(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
-        let __nt = super::__action1419::<>(__sym0, __sym1, __sym2);
+        let __nt = super::__action1420::<>(__sym0, __sym1, __sym2);
         __symbols.push((__start, __Symbol::Variant15(__nt), __end));
         (3, 262)
     }
@@ -28539,14 +28561,14 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // XorExpression<"no-withitems"> = XorExpression<"all">, "^", AndExpression<"all"> => ActionFn(1420);
+        // XorExpression<"no-withitems"> = XorExpression<"all">, "^", AndExpression<"all"> => ActionFn(1421);
         assert!(__symbols.len() >= 3);
         let __sym2 = __pop_Variant15(__symbols);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant15(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
-        let __nt = super::__action1420::<>(__sym0, __sym1, __sym2);
+        let __nt = super::__action1421::<>(__sym0, __sym1, __sym2);
         __symbols.push((__start, __Symbol::Variant15(__nt), __end));
         (3, 263)
     }
@@ -28572,13 +28594,13 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // YieldExpr = "yield", GenericList<TestOrStarExpr> => ActionFn(1648);
+        // YieldExpr = "yield", GenericList<TestOrStarExpr> => ActionFn(1649);
         assert!(__symbols.len() >= 2);
         let __sym1 = __pop_Variant15(__symbols);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym1.2;
-        let __nt = super::__action1648::<>(__sym0, __sym1);
+        let __nt = super::__action1649::<>(__sym0, __sym1);
         __symbols.push((__start, __Symbol::Variant15(__nt), __end));
         (2, 264)
     }
@@ -28589,11 +28611,11 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // YieldExpr = "yield" => ActionFn(1649);
+        // YieldExpr = "yield" => ActionFn(1650);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym0.2;
-        let __nt = super::__action1649::<>(__sym0);
+        let __nt = super::__action1650::<>(__sym0);
         __symbols.push((__start, __Symbol::Variant15(__nt), __end));
         (1, 264)
     }
@@ -28604,14 +28626,14 @@ mod __parse__Top {
         _: core::marker::PhantomData<()>,
     ) -> (usize, usize)
     {
-        // YieldExpr = "yield", "from", Test<"all"> => ActionFn(1422);
+        // YieldExpr = "yield", "from", Test<"all"> => ActionFn(1423);
         assert!(__symbols.len() >= 3);
         let __sym2 = __pop_Variant15(__symbols);
         let __sym1 = __pop_Variant0(__symbols);
         let __sym0 = __pop_Variant0(__symbols);
         let __start = __sym0.0;
         let __end = __sym2.2;
-        let __nt = super::__action1422::<>(__sym0, __sym1, __sym2);
+        let __nt = super::__action1423::<>(__sym0, __sym1, __sym2);
         __symbols.push((__start, __Symbol::Variant15(__nt), __end));
         (3, 264)
     }
@@ -30963,7 +30985,7 @@ fn __action156<
 fn __action157<
 >(
     (_, location, _): (TextSize, TextSize, TextSize),
-    (_, decorator_list, _): (TextSize, alloc::vec::Vec<ast::Expr>, TextSize),
+    (_, decorator_list, _): (TextSize, alloc::vec::Vec<ast::Decorator>, TextSize),
     (_, is_async, _): (TextSize, core::option::Option<token::Tok>, TextSize),
     (_, _, _): (TextSize, token::Tok, TextSize),
     (_, name, _): (TextSize, ast::Identifier, TextSize),
@@ -31062,7 +31084,7 @@ fn __action161<
 fn __action162<
 >(
     (_, location, _): (TextSize, TextSize, TextSize),
-    (_, decorator_list, _): (TextSize, alloc::vec::Vec<ast::Expr>, TextSize),
+    (_, decorator_list, _): (TextSize, alloc::vec::Vec<ast::Decorator>, TextSize),
     (_, _, _): (TextSize, token::Tok, TextSize),
     (_, name, _): (TextSize, ast::Identifier, TextSize),
     (_, a, _): (TextSize, core::option::Option<(token::Tok, ArgumentList, token::Tok)>, TextSize),
@@ -31095,11 +31117,12 @@ fn __action163<
     (_, location, _): (TextSize, TextSize, TextSize),
     (_, _, _): (TextSize, token::Tok, TextSize),
     (_, p, _): (TextSize, ast::Expr, TextSize),
+    (_, end_location, _): (TextSize, TextSize, TextSize),
     (_, _, _): (TextSize, token::Tok, TextSize),
-) -> ast::Expr
+) -> ast::Decorator
 {
     {
-        p
+        ast::Decorator { range: optional_range(location, end_location), expression: p }
     }
 }
 
@@ -32443,7 +32466,7 @@ fn __action271<
 >(
     __lookbehind: &TextSize,
     __lookahead: &TextSize,
-) -> alloc::vec::Vec<ast::Expr>
+) -> alloc::vec::Vec<ast::Decorator>
 {
     alloc::vec![]
 }
@@ -32451,8 +32474,8 @@ fn __action271<
 #[allow(clippy::too_many_arguments)]
 fn __action272<
 >(
-    (_, v, _): (TextSize, alloc::vec::Vec<ast::Expr>, TextSize),
-) -> alloc::vec::Vec<ast::Expr>
+    (_, v, _): (TextSize, alloc::vec::Vec<ast::Decorator>, TextSize),
+) -> alloc::vec::Vec<ast::Decorator>
 {
     v
 }
@@ -33685,8 +33708,8 @@ fn __action389<
 #[allow(clippy::too_many_arguments)]
 fn __action390<
 >(
-    (_, __0, _): (TextSize, ast::Expr, TextSize),
-) -> alloc::vec::Vec<ast::Expr>
+    (_, __0, _): (TextSize, ast::Decorator, TextSize),
+) -> alloc::vec::Vec<ast::Decorator>
 {
     alloc::vec![__0]
 }
@@ -33694,9 +33717,9 @@ fn __action390<
 #[allow(clippy::too_many_arguments)]
 fn __action391<
 >(
-    (_, v, _): (TextSize, alloc::vec::Vec<ast::Expr>, TextSize),
-    (_, e, _): (TextSize, ast::Expr, TextSize),
-) -> alloc::vec::Vec<ast::Expr>
+    (_, v, _): (TextSize, alloc::vec::Vec<ast::Decorator>, TextSize),
+    (_, e, _): (TextSize, ast::Decorator, TextSize),
+) -> alloc::vec::Vec<ast::Decorator>
 {
     { let mut v = v; v.push(e); v }
 }
@@ -37795,7 +37818,7 @@ fn __action636<
 fn __action637<
 >(
     __0: (TextSize, TextSize, TextSize),
-    __1: (TextSize, alloc::vec::Vec<ast::Expr>, TextSize),
+    __1: (TextSize, alloc::vec::Vec<ast::Decorator>, TextSize),
     __2: (TextSize, token::Tok, TextSize),
     __3: (TextSize, token::Tok, TextSize),
     __4: (TextSize, ast::Identifier, TextSize),
@@ -37828,7 +37851,7 @@ fn __action637<
 fn __action638<
 >(
     __0: (TextSize, TextSize, TextSize),
-    __1: (TextSize, alloc::vec::Vec<ast::Expr>, TextSize),
+    __1: (TextSize, alloc::vec::Vec<ast::Decorator>, TextSize),
     __2: (TextSize, token::Tok, TextSize),
     __3: (TextSize, ast::Identifier, TextSize),
     __4: (TextSize, ast::Arguments, TextSize),
@@ -37998,7 +38021,7 @@ fn __action643<
 fn __action644<
 >(
     __0: (TextSize, TextSize, TextSize),
-    __1: (TextSize, alloc::vec::Vec<ast::Expr>, TextSize),
+    __1: (TextSize, alloc::vec::Vec<ast::Decorator>, TextSize),
     __2: (TextSize, token::Tok, TextSize),
     __3: (TextSize, ast::Identifier, TextSize),
     __4: (TextSize, token::Tok, TextSize),
@@ -38031,7 +38054,7 @@ fn __action644<
 fn __action645<
 >(
     __0: (TextSize, TextSize, TextSize),
-    __1: (TextSize, alloc::vec::Vec<ast::Expr>, TextSize),
+    __1: (TextSize, alloc::vec::Vec<ast::Decorator>, TextSize),
     __2: (TextSize, token::Tok, TextSize),
     __3: (TextSize, ast::Identifier, TextSize),
     __4: (TextSize, token::Tok, TextSize),
@@ -40289,7 +40312,7 @@ fn __action737<
 #[allow(clippy::too_many_arguments)]
 fn __action738<
 >(
-    __0: (TextSize, alloc::vec::Vec<ast::Expr>, TextSize),
+    __0: (TextSize, alloc::vec::Vec<ast::Decorator>, TextSize),
     __1: (TextSize, token::Tok, TextSize),
     __2: (TextSize, ast::Identifier, TextSize),
     __3: (TextSize, token::Tok, TextSize),
@@ -40322,7 +40345,7 @@ fn __action738<
 #[allow(clippy::too_many_arguments)]
 fn __action739<
 >(
-    __0: (TextSize, alloc::vec::Vec<ast::Expr>, TextSize),
+    __0: (TextSize, alloc::vec::Vec<ast::Decorator>, TextSize),
     __1: (TextSize, token::Tok, TextSize),
     __2: (TextSize, ast::Identifier, TextSize),
     __3: (TextSize, token::Tok, TextSize),
@@ -40843,8 +40866,9 @@ fn __action758<
 >(
     __0: (TextSize, token::Tok, TextSize),
     __1: (TextSize, ast::Expr, TextSize),
-    __2: (TextSize, token::Tok, TextSize),
-) -> ast::Expr
+    __2: (TextSize, TextSize, TextSize),
+    __3: (TextSize, token::Tok, TextSize),
+) -> ast::Decorator
 {
     let __start0 = __0.0;
     let __end0 = __0.0;
@@ -40858,6 +40882,7 @@ fn __action758<
         __0,
         __1,
         __2,
+        __3,
     )
 }
 
@@ -41312,7 +41337,7 @@ fn __action776<
 #[allow(clippy::too_many_arguments)]
 fn __action777<
 >(
-    __0: (TextSize, alloc::vec::Vec<ast::Expr>, TextSize),
+    __0: (TextSize, alloc::vec::Vec<ast::Decorator>, TextSize),
     __1: (TextSize, token::Tok, TextSize),
     __2: (TextSize, token::Tok, TextSize),
     __3: (TextSize, ast::Identifier, TextSize),
@@ -41345,7 +41370,7 @@ fn __action777<
 #[allow(clippy::too_many_arguments)]
 fn __action778<
 >(
-    __0: (TextSize, alloc::vec::Vec<ast::Expr>, TextSize),
+    __0: (TextSize, alloc::vec::Vec<ast::Decorator>, TextSize),
     __1: (TextSize, token::Tok, TextSize),
     __2: (TextSize, ast::Identifier, TextSize),
     __3: (TextSize, ast::Arguments, TextSize),
@@ -47795,7 +47820,7 @@ fn __action1041<
 #[allow(clippy::too_many_arguments)]
 fn __action1042<
 >(
-    __0: (TextSize, alloc::vec::Vec<ast::Expr>, TextSize),
+    __0: (TextSize, alloc::vec::Vec<ast::Decorator>, TextSize),
     __1: (TextSize, token::Tok, TextSize),
     __2: (TextSize, token::Tok, TextSize),
     __3: (TextSize, ast::Identifier, TextSize),
@@ -47828,7 +47853,7 @@ fn __action1042<
 #[allow(clippy::too_many_arguments)]
 fn __action1043<
 >(
-    __0: (TextSize, alloc::vec::Vec<ast::Expr>, TextSize),
+    __0: (TextSize, alloc::vec::Vec<ast::Decorator>, TextSize),
     __1: (TextSize, token::Tok, TextSize),
     __2: (TextSize, token::Tok, TextSize),
     __3: (TextSize, ast::Identifier, TextSize),
@@ -47859,7 +47884,7 @@ fn __action1043<
 #[allow(clippy::too_many_arguments)]
 fn __action1044<
 >(
-    __0: (TextSize, alloc::vec::Vec<ast::Expr>, TextSize),
+    __0: (TextSize, alloc::vec::Vec<ast::Decorator>, TextSize),
     __1: (TextSize, token::Tok, TextSize),
     __2: (TextSize, ast::Identifier, TextSize),
     __3: (TextSize, ast::Arguments, TextSize),
@@ -47890,7 +47915,7 @@ fn __action1044<
 #[allow(clippy::too_many_arguments)]
 fn __action1045<
 >(
-    __0: (TextSize, alloc::vec::Vec<ast::Expr>, TextSize),
+    __0: (TextSize, alloc::vec::Vec<ast::Decorator>, TextSize),
     __1: (TextSize, token::Tok, TextSize),
     __2: (TextSize, ast::Identifier, TextSize),
     __3: (TextSize, ast::Arguments, TextSize),
@@ -52404,6 +52429,29 @@ fn __action1229<
 fn __action1230<
 >(
     __0: (TextSize, token::Tok, TextSize),
+    __1: (TextSize, ast::Expr, TextSize),
+    __2: (TextSize, token::Tok, TextSize),
+) -> ast::Decorator
+{
+    let __start0 = __1.2;
+    let __end0 = __2.0;
+    let __temp0 = __action370(
+        &__start0,
+        &__end0,
+    );
+    let __temp0 = (__start0, __temp0, __end0);
+    __action758(
+        __0,
+        __1,
+        __temp0,
+        __2,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn __action1231<
+>(
+    __0: (TextSize, token::Tok, TextSize),
     __1: (TextSize, Vec<ast::Expr>, TextSize),
 ) -> ast::Stmt
 {
@@ -52422,7 +52470,7 @@ fn __action1230<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1231<
+fn __action1232<
 >(
     __0: (TextSize, ast::Expr, TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -52445,7 +52493,7 @@ fn __action1231<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1232<
+fn __action1233<
 >(
     __0: (TextSize, ast::Expr, TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -52468,7 +52516,7 @@ fn __action1232<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1233<
+fn __action1234<
 >(
     __0: (TextSize, ast::Expr, TextSize),
     __1: (TextSize, alloc::vec::Vec<ast::Expr>, TextSize),
@@ -52489,7 +52537,7 @@ fn __action1233<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1234<
+fn __action1235<
 >(
     __0: (TextSize, ast::Expr, TextSize),
     __1: (TextSize, ast::Operator, TextSize),
@@ -52512,7 +52560,7 @@ fn __action1234<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1235<
+fn __action1236<
 >(
     __0: (TextSize, ast::Expr, TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -52537,7 +52585,7 @@ fn __action1235<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1236<
+fn __action1237<
 >(
     __0: (TextSize, ast::Unaryop, TextSize),
     __1: (TextSize, ast::Expr, TextSize),
@@ -52558,7 +52606,7 @@ fn __action1236<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1237<
+fn __action1238<
 >(
     __0: (TextSize, ast::Unaryop, TextSize),
     __1: (TextSize, ast::Expr, TextSize),
@@ -52579,7 +52627,7 @@ fn __action1237<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1238<
+fn __action1239<
 >(
     __0: (TextSize, token::Tok, TextSize),
 ) -> ast::Stmt
@@ -52598,7 +52646,7 @@ fn __action1238<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1239<
+fn __action1240<
 >(
     __0: (TextSize, token::Tok, TextSize),
 ) -> ast::Stmt
@@ -52617,7 +52665,7 @@ fn __action1239<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1240<
+fn __action1241<
 >(
     __0: (TextSize, token::Tok, TextSize),
     __1: (TextSize, core::option::Option<ast::Expr>, TextSize),
@@ -52638,7 +52686,7 @@ fn __action1240<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1241<
+fn __action1242<
 >(
     __0: (TextSize, ast::Expr, TextSize),
 ) -> ast::Stmt
@@ -52657,7 +52705,7 @@ fn __action1241<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1242<
+fn __action1243<
 >(
     __0: (TextSize, ast::Expr, TextSize),
     __1: (TextSize, core::option::Option<Vec<ast::Comprehension>>, TextSize),
@@ -52678,7 +52726,7 @@ fn __action1242<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1243<
+fn __action1244<
 >(
     __0: (TextSize, ast::Identifier, TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -52701,7 +52749,7 @@ fn __action1243<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1244<
+fn __action1245<
 >(
     __0: (TextSize, token::Tok, TextSize),
     __1: (TextSize, ast::Expr, TextSize),
@@ -52722,7 +52770,7 @@ fn __action1244<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1245<
+fn __action1246<
 >(
     __0: (TextSize, token::Tok, TextSize),
     __1: (TextSize, ast::Expr, TextSize),
@@ -52743,7 +52791,7 @@ fn __action1245<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1246<
+fn __action1247<
 >(
     __0: (TextSize, Vec<ast::Expr>, TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -52764,7 +52812,7 @@ fn __action1246<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1247<
+fn __action1248<
 >(
     __0: (TextSize, Vec<ast::Expr>, TextSize),
 ) -> ast::Expr
@@ -52783,7 +52831,7 @@ fn __action1247<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1248<
+fn __action1249<
 >(
     __0: (TextSize, Vec<ast::Expr>, TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -52804,7 +52852,7 @@ fn __action1248<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1249<
+fn __action1250<
 >(
     __0: (TextSize, Vec<ast::Expr>, TextSize),
 ) -> ast::Expr
@@ -52823,7 +52871,7 @@ fn __action1249<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1250<
+fn __action1251<
 >(
     __0: (TextSize, token::Tok, TextSize),
     __1: (TextSize, Vec<ast::Identifier>, TextSize),
@@ -52844,7 +52892,7 @@ fn __action1250<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1251<
+fn __action1252<
 >(
     __0: (TextSize, ast::Identifier, TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -52867,7 +52915,7 @@ fn __action1251<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1252<
+fn __action1253<
 >(
     __0: (TextSize, ast::Identifier, TextSize),
 ) -> ast::Alias
@@ -52886,7 +52934,7 @@ fn __action1252<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1253<
+fn __action1254<
 >(
     __0: (TextSize, ast::Identifier, TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -52909,7 +52957,7 @@ fn __action1253<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1254<
+fn __action1255<
 >(
     __0: (TextSize, ast::Identifier, TextSize),
 ) -> ast::Alias
@@ -52928,7 +52976,7 @@ fn __action1254<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1255<
+fn __action1256<
 >(
     __0: (TextSize, Vec<ast::Alias>, TextSize),
 ) -> Vec<ast::Alias>
@@ -52947,7 +52995,7 @@ fn __action1255<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1256<
+fn __action1257<
 >(
     __0: (TextSize, token::Tok, TextSize),
     __1: (TextSize, Vec<ast::Alias>, TextSize),
@@ -52972,7 +53020,7 @@ fn __action1256<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1257<
+fn __action1258<
 >(
     __0: (TextSize, token::Tok, TextSize),
     __1: (TextSize, Vec<ast::Alias>, TextSize),
@@ -52995,7 +53043,7 @@ fn __action1257<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1258<
+fn __action1259<
 >(
     __0: (TextSize, token::Tok, TextSize),
 ) -> Vec<ast::Alias>
@@ -53014,7 +53062,7 @@ fn __action1258<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1259<
+fn __action1260<
 >(
     __0: (TextSize, token::Tok, TextSize),
     __1: (TextSize, Vec<ast::Alias>, TextSize),
@@ -53035,7 +53083,7 @@ fn __action1259<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1260<
+fn __action1261<
 >(
     __0: (TextSize, token::Tok, TextSize),
     __1: (TextSize, (Option<ast::Int>, Option<ast::Identifier>), TextSize),
@@ -53060,7 +53108,7 @@ fn __action1260<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1261<
+fn __action1262<
 >(
     __0: (TextSize, token::Tok, TextSize),
     __1: (TextSize, core::option::Option<ast::Arguments>, TextSize),
@@ -53085,7 +53133,7 @@ fn __action1261<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1262<
+fn __action1263<
 >(
     __0: (TextSize, token::Tok, TextSize),
 ) -> ast::Pattern
@@ -53104,7 +53152,7 @@ fn __action1262<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1263<
+fn __action1264<
 >(
     __0: (TextSize, token::Tok, TextSize),
 ) -> ast::Pattern
@@ -53123,7 +53171,7 @@ fn __action1263<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1264<
+fn __action1265<
 >(
     __0: (TextSize, token::Tok, TextSize),
 ) -> ast::Pattern
@@ -53142,7 +53190,7 @@ fn __action1264<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1265<
+fn __action1266<
 >(
     __0: (TextSize, ast::Expr, TextSize),
 ) -> ast::Pattern
@@ -53161,7 +53209,7 @@ fn __action1265<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1266<
+fn __action1267<
 >(
     __0: (TextSize, ast::Expr, TextSize),
 ) -> ast::Pattern
@@ -53180,7 +53228,7 @@ fn __action1266<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1267<
+fn __action1268<
 >(
     __0: (TextSize, alloc::vec::Vec<(TextSize, (String, StringKind, bool), TextSize)>, TextSize),
 ) -> Result<ast::Pattern,__lalrpop_util::ParseError<TextSize,token::Tok,LexicalError>>
@@ -53199,7 +53247,7 @@ fn __action1267<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1268<
+fn __action1269<
 >(
     __0: (TextSize, token::Tok, TextSize),
 ) -> ast::Expr
@@ -53218,7 +53266,7 @@ fn __action1268<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1269<
+fn __action1270<
 >(
     __0: (TextSize, token::Tok, TextSize),
 ) -> ast::Expr
@@ -53237,7 +53285,7 @@ fn __action1269<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1270<
+fn __action1271<
 >(
     __0: (TextSize, token::Tok, TextSize),
 ) -> ast::Expr
@@ -53256,7 +53304,7 @@ fn __action1270<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1271<
+fn __action1272<
 >(
     __0: (TextSize, token::Tok, TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -53277,7 +53325,7 @@ fn __action1271<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1272<
+fn __action1273<
 >(
     __0: (TextSize, token::Tok, TextSize),
     __1: (TextSize, Vec<(ast::Expr, ast::Pattern)>, TextSize),
@@ -53302,7 +53350,7 @@ fn __action1272<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1273<
+fn __action1274<
 >(
     __0: (TextSize, token::Tok, TextSize),
     __1: (TextSize, Vec<(ast::Expr, ast::Pattern)>, TextSize),
@@ -53325,7 +53373,7 @@ fn __action1273<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1274<
+fn __action1275<
 >(
     __0: (TextSize, token::Tok, TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -53352,7 +53400,7 @@ fn __action1274<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1275<
+fn __action1276<
 >(
     __0: (TextSize, token::Tok, TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -53377,7 +53425,7 @@ fn __action1275<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1276<
+fn __action1277<
 >(
     __0: (TextSize, token::Tok, TextSize),
     __1: (TextSize, Vec<(ast::Expr, ast::Pattern)>, TextSize),
@@ -53408,7 +53456,7 @@ fn __action1276<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1277<
+fn __action1278<
 >(
     __0: (TextSize, token::Tok, TextSize),
     __1: (TextSize, Vec<(ast::Expr, ast::Pattern)>, TextSize),
@@ -53437,7 +53485,7 @@ fn __action1277<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1278<
+fn __action1279<
 >(
     __0: (TextSize, ast::Identifier, TextSize),
 ) -> ast::Expr
@@ -53456,7 +53504,7 @@ fn __action1278<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1279<
+fn __action1280<
 >(
     __0: (TextSize, ast::Expr, TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -53479,7 +53527,7 @@ fn __action1279<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1280<
+fn __action1281<
 >(
     __0: (TextSize, ast::Expr, TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -53502,7 +53550,7 @@ fn __action1280<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1281<
+fn __action1282<
 >(
     __0: (TextSize, ast::Identifier, TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -53525,7 +53573,7 @@ fn __action1281<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1282<
+fn __action1283<
 >(
     __0: (TextSize, token::Tok, TextSize),
     __1: (TextSize, Vec<ast::Identifier>, TextSize),
@@ -53546,7 +53594,7 @@ fn __action1282<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1283<
+fn __action1284<
 >(
     __0: (TextSize, token::Tok, TextSize),
     __1: (TextSize, ast::Expr, TextSize),
@@ -53567,7 +53615,7 @@ fn __action1283<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1284<
+fn __action1285<
 >(
     __0: (TextSize, token::Tok, TextSize),
     __1: (TextSize, ast::Expr, TextSize),
@@ -53588,7 +53636,7 @@ fn __action1284<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1285<
+fn __action1286<
 >(
     __0: (TextSize, Vec<ast::Pattern>, TextSize),
 ) -> ast::Pattern
@@ -53607,7 +53655,7 @@ fn __action1285<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1286<
+fn __action1287<
 >(
     __0: (TextSize, alloc::vec::Vec<ast::Expr>, TextSize),
     __1: (TextSize, ast::Expr, TextSize),
@@ -53628,7 +53676,7 @@ fn __action1286<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1287<
+fn __action1288<
 >(
     __0: (TextSize, alloc::vec::Vec<ast::Expr>, TextSize),
     __1: (TextSize, ast::Expr, TextSize),
@@ -53649,7 +53697,7 @@ fn __action1287<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1288<
+fn __action1289<
 >(
     __0: (TextSize, (Vec<(ast::Arg, Option<ast::Expr>)>, Vec<(ast::Arg, Option<ast::Expr>)>), TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -53680,7 +53728,7 @@ fn __action1288<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1289<
+fn __action1290<
 >(
     __0: (TextSize, (Vec<(ast::Arg, Option<ast::Expr>)>, Vec<(ast::Arg, Option<ast::Expr>)>), TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -53709,7 +53757,7 @@ fn __action1289<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1290<
+fn __action1291<
 >(
     __0: (TextSize, (Vec<(ast::Arg, Option<ast::Expr>)>, Vec<(ast::Arg, Option<ast::Expr>)>), TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -53742,7 +53790,7 @@ fn __action1290<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1291<
+fn __action1292<
 >(
     __0: (TextSize, (Vec<(ast::Arg, Option<ast::Expr>)>, Vec<(ast::Arg, Option<ast::Expr>)>), TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -53773,7 +53821,7 @@ fn __action1291<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1292<
+fn __action1293<
 >(
     __0: (TextSize, (Vec<(ast::Arg, Option<ast::Expr>)>, Vec<(ast::Arg, Option<ast::Expr>)>), TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -53800,7 +53848,7 @@ fn __action1292<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1293<
+fn __action1294<
 >(
     __0: (TextSize, (Vec<(ast::Arg, Option<ast::Expr>)>, Vec<(ast::Arg, Option<ast::Expr>)>), TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -53825,7 +53873,7 @@ fn __action1293<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1294<
+fn __action1295<
 >(
     __0: (TextSize, (Vec<(ast::Arg, Option<ast::Expr>)>, Vec<(ast::Arg, Option<ast::Expr>)>), TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -53854,7 +53902,7 @@ fn __action1294<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1295<
+fn __action1296<
 >(
     __0: (TextSize, (Vec<(ast::Arg, Option<ast::Expr>)>, Vec<(ast::Arg, Option<ast::Expr>)>), TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -53881,7 +53929,7 @@ fn __action1295<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1296<
+fn __action1297<
 >(
     __0: (TextSize, (Vec<(ast::Arg, Option<ast::Expr>)>, Vec<(ast::Arg, Option<ast::Expr>)>), TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -53902,7 +53950,7 @@ fn __action1296<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1297<
+fn __action1298<
 >(
     __0: (TextSize, (Vec<(ast::Arg, Option<ast::Expr>)>, Vec<(ast::Arg, Option<ast::Expr>)>), TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -53931,7 +53979,7 @@ fn __action1297<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1298<
+fn __action1299<
 >(
     __0: (TextSize, (Vec<(ast::Arg, Option<ast::Expr>)>, Vec<(ast::Arg, Option<ast::Expr>)>), TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -53958,7 +54006,7 @@ fn __action1298<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1299<
+fn __action1300<
 >(
     __0: (TextSize, (Vec<(ast::Arg, Option<ast::Expr>)>, Vec<(ast::Arg, Option<ast::Expr>)>), TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -53989,7 +54037,7 @@ fn __action1299<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1300<
+fn __action1301<
 >(
     __0: (TextSize, (Vec<(ast::Arg, Option<ast::Expr>)>, Vec<(ast::Arg, Option<ast::Expr>)>), TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -54018,7 +54066,7 @@ fn __action1300<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1301<
+fn __action1302<
 >(
     __0: (TextSize, (Vec<(ast::Arg, Option<ast::Expr>)>, Vec<(ast::Arg, Option<ast::Expr>)>), TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -54043,7 +54091,7 @@ fn __action1301<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1302<
+fn __action1303<
 >(
     __0: (TextSize, (Vec<(ast::Arg, Option<ast::Expr>)>, Vec<(ast::Arg, Option<ast::Expr>)>), TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -54066,7 +54114,7 @@ fn __action1302<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1303<
+fn __action1304<
 >(
     __0: (TextSize, (Vec<(ast::Arg, Option<ast::Expr>)>, Vec<(ast::Arg, Option<ast::Expr>)>), TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -54093,7 +54141,7 @@ fn __action1303<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1304<
+fn __action1305<
 >(
     __0: (TextSize, (Vec<(ast::Arg, Option<ast::Expr>)>, Vec<(ast::Arg, Option<ast::Expr>)>), TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -54118,7 +54166,7 @@ fn __action1304<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1305<
+fn __action1306<
 >(
     __0: (TextSize, (Vec<(ast::Arg, Option<ast::Expr>)>, Vec<(ast::Arg, Option<ast::Expr>)>), TextSize),
 ) -> Result<ast::Arguments,__lalrpop_util::ParseError<TextSize,token::Tok,LexicalError>>
@@ -54137,7 +54185,7 @@ fn __action1305<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1306<
+fn __action1307<
 >(
     __0: (TextSize, (Vec<(ast::Arg, Option<ast::Expr>)>, Vec<(ast::Arg, Option<ast::Expr>)>), TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -54162,7 +54210,7 @@ fn __action1306<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1307<
+fn __action1308<
 >(
     __0: (TextSize, (Vec<(ast::Arg, Option<ast::Expr>)>, Vec<(ast::Arg, Option<ast::Expr>)>), TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -54185,7 +54233,7 @@ fn __action1307<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1308<
+fn __action1309<
 >(
     __0: (TextSize, token::Tok, TextSize),
     __1: (TextSize, ast::Arg, TextSize),
@@ -54212,7 +54260,7 @@ fn __action1308<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1309<
+fn __action1310<
 >(
     __0: (TextSize, token::Tok, TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -54237,7 +54285,7 @@ fn __action1309<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1310<
+fn __action1311<
 >(
     __0: (TextSize, token::Tok, TextSize),
     __1: (TextSize, ast::Arg, TextSize),
@@ -54266,7 +54314,7 @@ fn __action1310<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1311<
+fn __action1312<
 >(
     __0: (TextSize, token::Tok, TextSize),
     __1: (TextSize, alloc::vec::Vec<(ast::Arg, Option<ast::Expr>)>, TextSize),
@@ -54293,7 +54341,7 @@ fn __action1311<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1312<
+fn __action1313<
 >(
     __0: (TextSize, token::Tok, TextSize),
     __1: (TextSize, ast::Arg, TextSize),
@@ -54316,7 +54364,7 @@ fn __action1312<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1313<
+fn __action1314<
 >(
     __0: (TextSize, token::Tok, TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -54337,7 +54385,7 @@ fn __action1313<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1314<
+fn __action1315<
 >(
     __0: (TextSize, token::Tok, TextSize),
     __1: (TextSize, ast::Arg, TextSize),
@@ -54362,7 +54410,7 @@ fn __action1314<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1315<
+fn __action1316<
 >(
     __0: (TextSize, token::Tok, TextSize),
     __1: (TextSize, alloc::vec::Vec<(ast::Arg, Option<ast::Expr>)>, TextSize),
@@ -54385,7 +54433,7 @@ fn __action1315<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1316<
+fn __action1317<
 >(
     __0: (TextSize, token::Tok, TextSize),
     __1: (TextSize, ast::Arg, TextSize),
@@ -54410,7 +54458,7 @@ fn __action1316<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1317<
+fn __action1318<
 >(
     __0: (TextSize, token::Tok, TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -54433,7 +54481,7 @@ fn __action1317<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1318<
+fn __action1319<
 >(
     __0: (TextSize, token::Tok, TextSize),
     __1: (TextSize, ast::Arg, TextSize),
@@ -54460,7 +54508,7 @@ fn __action1318<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1319<
+fn __action1320<
 >(
     __0: (TextSize, token::Tok, TextSize),
     __1: (TextSize, alloc::vec::Vec<(ast::Arg, Option<ast::Expr>)>, TextSize),
@@ -54485,7 +54533,7 @@ fn __action1319<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1320<
+fn __action1321<
 >(
     __0: (TextSize, token::Tok, TextSize),
     __1: (TextSize, ast::Arg, TextSize),
@@ -54506,7 +54554,7 @@ fn __action1320<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1321<
+fn __action1322<
 >(
     __0: (TextSize, token::Tok, TextSize),
 ) -> Result<ast::Arguments,__lalrpop_util::ParseError<TextSize,token::Tok,LexicalError>>
@@ -54525,7 +54573,7 @@ fn __action1321<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1322<
+fn __action1323<
 >(
     __0: (TextSize, token::Tok, TextSize),
     __1: (TextSize, ast::Arg, TextSize),
@@ -54548,7 +54596,7 @@ fn __action1322<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1323<
+fn __action1324<
 >(
     __0: (TextSize, token::Tok, TextSize),
     __1: (TextSize, alloc::vec::Vec<(ast::Arg, Option<ast::Expr>)>, TextSize),
@@ -54569,7 +54617,7 @@ fn __action1323<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1324<
+fn __action1325<
 >(
     __0: (TextSize, Option<Box<ast::Arg>>, TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -54590,7 +54638,7 @@ fn __action1324<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1325<
+fn __action1326<
 >(
     __0: (TextSize, Option<Box<ast::Arg>>, TextSize),
 ) -> ast::Arguments
@@ -54609,7 +54657,7 @@ fn __action1325<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1326<
+fn __action1327<
 >(
     __0: (TextSize, (Vec<(ast::Arg, Option<ast::Expr>)>, Vec<(ast::Arg, Option<ast::Expr>)>), TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -54640,7 +54688,7 @@ fn __action1326<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1327<
+fn __action1328<
 >(
     __0: (TextSize, (Vec<(ast::Arg, Option<ast::Expr>)>, Vec<(ast::Arg, Option<ast::Expr>)>), TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -54669,7 +54717,7 @@ fn __action1327<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1328<
+fn __action1329<
 >(
     __0: (TextSize, (Vec<(ast::Arg, Option<ast::Expr>)>, Vec<(ast::Arg, Option<ast::Expr>)>), TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -54702,7 +54750,7 @@ fn __action1328<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1329<
+fn __action1330<
 >(
     __0: (TextSize, (Vec<(ast::Arg, Option<ast::Expr>)>, Vec<(ast::Arg, Option<ast::Expr>)>), TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -54733,7 +54781,7 @@ fn __action1329<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1330<
+fn __action1331<
 >(
     __0: (TextSize, (Vec<(ast::Arg, Option<ast::Expr>)>, Vec<(ast::Arg, Option<ast::Expr>)>), TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -54760,7 +54808,7 @@ fn __action1330<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1331<
+fn __action1332<
 >(
     __0: (TextSize, (Vec<(ast::Arg, Option<ast::Expr>)>, Vec<(ast::Arg, Option<ast::Expr>)>), TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -54785,7 +54833,7 @@ fn __action1331<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1332<
+fn __action1333<
 >(
     __0: (TextSize, (Vec<(ast::Arg, Option<ast::Expr>)>, Vec<(ast::Arg, Option<ast::Expr>)>), TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -54814,7 +54862,7 @@ fn __action1332<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1333<
+fn __action1334<
 >(
     __0: (TextSize, (Vec<(ast::Arg, Option<ast::Expr>)>, Vec<(ast::Arg, Option<ast::Expr>)>), TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -54841,7 +54889,7 @@ fn __action1333<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1334<
+fn __action1335<
 >(
     __0: (TextSize, (Vec<(ast::Arg, Option<ast::Expr>)>, Vec<(ast::Arg, Option<ast::Expr>)>), TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -54862,7 +54910,7 @@ fn __action1334<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1335<
+fn __action1336<
 >(
     __0: (TextSize, (Vec<(ast::Arg, Option<ast::Expr>)>, Vec<(ast::Arg, Option<ast::Expr>)>), TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -54891,7 +54939,7 @@ fn __action1335<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1336<
+fn __action1337<
 >(
     __0: (TextSize, (Vec<(ast::Arg, Option<ast::Expr>)>, Vec<(ast::Arg, Option<ast::Expr>)>), TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -54918,7 +54966,7 @@ fn __action1336<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1337<
+fn __action1338<
 >(
     __0: (TextSize, (Vec<(ast::Arg, Option<ast::Expr>)>, Vec<(ast::Arg, Option<ast::Expr>)>), TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -54949,7 +54997,7 @@ fn __action1337<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1338<
+fn __action1339<
 >(
     __0: (TextSize, (Vec<(ast::Arg, Option<ast::Expr>)>, Vec<(ast::Arg, Option<ast::Expr>)>), TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -54978,7 +55026,7 @@ fn __action1338<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1339<
+fn __action1340<
 >(
     __0: (TextSize, (Vec<(ast::Arg, Option<ast::Expr>)>, Vec<(ast::Arg, Option<ast::Expr>)>), TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -55003,7 +55051,7 @@ fn __action1339<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1340<
+fn __action1341<
 >(
     __0: (TextSize, (Vec<(ast::Arg, Option<ast::Expr>)>, Vec<(ast::Arg, Option<ast::Expr>)>), TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -55026,7 +55074,7 @@ fn __action1340<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1341<
+fn __action1342<
 >(
     __0: (TextSize, (Vec<(ast::Arg, Option<ast::Expr>)>, Vec<(ast::Arg, Option<ast::Expr>)>), TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -55053,7 +55101,7 @@ fn __action1341<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1342<
+fn __action1343<
 >(
     __0: (TextSize, (Vec<(ast::Arg, Option<ast::Expr>)>, Vec<(ast::Arg, Option<ast::Expr>)>), TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -55078,7 +55126,7 @@ fn __action1342<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1343<
+fn __action1344<
 >(
     __0: (TextSize, (Vec<(ast::Arg, Option<ast::Expr>)>, Vec<(ast::Arg, Option<ast::Expr>)>), TextSize),
 ) -> Result<ast::Arguments,__lalrpop_util::ParseError<TextSize,token::Tok,LexicalError>>
@@ -55097,7 +55145,7 @@ fn __action1343<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1344<
+fn __action1345<
 >(
     __0: (TextSize, (Vec<(ast::Arg, Option<ast::Expr>)>, Vec<(ast::Arg, Option<ast::Expr>)>), TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -55122,7 +55170,7 @@ fn __action1344<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1345<
+fn __action1346<
 >(
     __0: (TextSize, (Vec<(ast::Arg, Option<ast::Expr>)>, Vec<(ast::Arg, Option<ast::Expr>)>), TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -55145,7 +55193,7 @@ fn __action1345<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1346<
+fn __action1347<
 >(
     __0: (TextSize, token::Tok, TextSize),
     __1: (TextSize, ast::Arg, TextSize),
@@ -55172,7 +55220,7 @@ fn __action1346<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1347<
+fn __action1348<
 >(
     __0: (TextSize, token::Tok, TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -55197,7 +55245,7 @@ fn __action1347<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1348<
+fn __action1349<
 >(
     __0: (TextSize, token::Tok, TextSize),
     __1: (TextSize, ast::Arg, TextSize),
@@ -55226,7 +55274,7 @@ fn __action1348<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1349<
+fn __action1350<
 >(
     __0: (TextSize, token::Tok, TextSize),
     __1: (TextSize, alloc::vec::Vec<(ast::Arg, Option<ast::Expr>)>, TextSize),
@@ -55253,7 +55301,7 @@ fn __action1349<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1350<
+fn __action1351<
 >(
     __0: (TextSize, token::Tok, TextSize),
     __1: (TextSize, ast::Arg, TextSize),
@@ -55276,7 +55324,7 @@ fn __action1350<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1351<
+fn __action1352<
 >(
     __0: (TextSize, token::Tok, TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -55297,7 +55345,7 @@ fn __action1351<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1352<
+fn __action1353<
 >(
     __0: (TextSize, token::Tok, TextSize),
     __1: (TextSize, ast::Arg, TextSize),
@@ -55322,7 +55370,7 @@ fn __action1352<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1353<
+fn __action1354<
 >(
     __0: (TextSize, token::Tok, TextSize),
     __1: (TextSize, alloc::vec::Vec<(ast::Arg, Option<ast::Expr>)>, TextSize),
@@ -55345,7 +55393,7 @@ fn __action1353<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1354<
+fn __action1355<
 >(
     __0: (TextSize, token::Tok, TextSize),
     __1: (TextSize, ast::Arg, TextSize),
@@ -55370,7 +55418,7 @@ fn __action1354<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1355<
+fn __action1356<
 >(
     __0: (TextSize, token::Tok, TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -55393,7 +55441,7 @@ fn __action1355<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1356<
+fn __action1357<
 >(
     __0: (TextSize, token::Tok, TextSize),
     __1: (TextSize, ast::Arg, TextSize),
@@ -55420,7 +55468,7 @@ fn __action1356<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1357<
+fn __action1358<
 >(
     __0: (TextSize, token::Tok, TextSize),
     __1: (TextSize, alloc::vec::Vec<(ast::Arg, Option<ast::Expr>)>, TextSize),
@@ -55445,7 +55493,7 @@ fn __action1357<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1358<
+fn __action1359<
 >(
     __0: (TextSize, token::Tok, TextSize),
     __1: (TextSize, ast::Arg, TextSize),
@@ -55466,7 +55514,7 @@ fn __action1358<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1359<
+fn __action1360<
 >(
     __0: (TextSize, token::Tok, TextSize),
 ) -> Result<ast::Arguments,__lalrpop_util::ParseError<TextSize,token::Tok,LexicalError>>
@@ -55485,7 +55533,7 @@ fn __action1359<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1360<
+fn __action1361<
 >(
     __0: (TextSize, token::Tok, TextSize),
     __1: (TextSize, ast::Arg, TextSize),
@@ -55508,7 +55556,7 @@ fn __action1360<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1361<
+fn __action1362<
 >(
     __0: (TextSize, token::Tok, TextSize),
     __1: (TextSize, alloc::vec::Vec<(ast::Arg, Option<ast::Expr>)>, TextSize),
@@ -55529,7 +55577,7 @@ fn __action1361<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1362<
+fn __action1363<
 >(
     __0: (TextSize, Option<Box<ast::Arg>>, TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -55550,7 +55598,7 @@ fn __action1362<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1363<
+fn __action1364<
 >(
     __0: (TextSize, Option<Box<ast::Arg>>, TextSize),
 ) -> ast::Arguments
@@ -55569,7 +55617,7 @@ fn __action1363<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1364<
+fn __action1365<
 >(
     __0: (TextSize, token::Tok, TextSize),
     __1: (TextSize, core::option::Option<ast::Arguments>, TextSize),
@@ -55592,7 +55640,7 @@ fn __action1364<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1365<
+fn __action1366<
 >(
     __0: (TextSize, token::Tok, TextSize),
 ) -> ast::Stmt
@@ -55611,7 +55659,7 @@ fn __action1365<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1366<
+fn __action1367<
 >(
     __0: (TextSize, ast::Pattern, TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -55632,7 +55680,7 @@ fn __action1366<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1367<
+fn __action1368<
 >(
     __0: (TextSize, Vec<ast::Pattern>, TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -55653,7 +55701,7 @@ fn __action1367<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1368<
+fn __action1369<
 >(
     __0: (TextSize, Vec<ast::Pattern>, TextSize),
 ) -> ast::Pattern
@@ -55672,7 +55720,7 @@ fn __action1368<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1369<
+fn __action1370<
 >(
     __0: (TextSize, ast::Expr, TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -55695,7 +55743,7 @@ fn __action1369<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1370<
+fn __action1371<
 >(
     __0: (TextSize, ast::Expr, TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -55718,7 +55766,7 @@ fn __action1370<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1371<
+fn __action1372<
 >(
     __0: (TextSize, token::Tok, TextSize),
 ) -> ast::Stmt
@@ -55737,7 +55785,7 @@ fn __action1371<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1372<
+fn __action1373<
 >(
     __0: (TextSize, token::Tok, TextSize),
     __1: (TextSize, ast::Expr, TextSize),
@@ -55762,7 +55810,7 @@ fn __action1372<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1373<
+fn __action1374<
 >(
     __0: (TextSize, token::Tok, TextSize),
     __1: (TextSize, ast::Expr, TextSize),
@@ -55783,7 +55831,7 @@ fn __action1373<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1374<
+fn __action1375<
 >(
     __0: (TextSize, token::Tok, TextSize),
     __1: (TextSize, ast::Pattern, TextSize),
@@ -55806,7 +55854,7 @@ fn __action1374<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1375<
+fn __action1376<
 >(
     __0: (TextSize, token::Tok, TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -55827,7 +55875,7 @@ fn __action1375<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1376<
+fn __action1377<
 >(
     __0: (TextSize, token::Tok, TextSize),
     __1: (TextSize, ast::Pattern, TextSize),
@@ -55852,7 +55900,7 @@ fn __action1376<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1377<
+fn __action1378<
 >(
     __0: (TextSize, token::Tok, TextSize),
     __1: (TextSize, alloc::vec::Vec<ast::Pattern>, TextSize),
@@ -55879,7 +55927,7 @@ fn __action1377<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1378<
+fn __action1379<
 >(
     __0: (TextSize, token::Tok, TextSize),
     __1: (TextSize, alloc::vec::Vec<ast::Pattern>, TextSize),
@@ -55904,7 +55952,7 @@ fn __action1378<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1379<
+fn __action1380<
 >(
     __0: (TextSize, token::Tok, TextSize),
     __1: (TextSize, Vec<ast::Pattern>, TextSize),
@@ -55927,7 +55975,7 @@ fn __action1379<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1380<
+fn __action1381<
 >(
     __0: (TextSize, ast::Expr, TextSize),
     __1: (TextSize, ast::Operator, TextSize),
@@ -55950,7 +55998,7 @@ fn __action1380<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1381<
+fn __action1382<
 >(
     __0: (TextSize, ast::Expr, TextSize),
     __1: (TextSize, ast::Operator, TextSize),
@@ -55973,7 +56021,7 @@ fn __action1381<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1382<
+fn __action1383<
 >(
     __0: (TextSize, token::Tok, TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -56002,7 +56050,7 @@ fn __action1382<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1383<
+fn __action1384<
 >(
     __0: (TextSize, token::Tok, TextSize),
     __1: (TextSize, ast::Expr, TextSize),
@@ -56029,7 +56077,7 @@ fn __action1383<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1384<
+fn __action1385<
 >(
     __0: (TextSize, token::Tok, TextSize),
     __1: (TextSize, ast::Expr, TextSize),
@@ -56050,7 +56098,7 @@ fn __action1384<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1385<
+fn __action1386<
 >(
     __0: (TextSize, token::Tok, TextSize),
     __1: (TextSize, ast::Identifier, TextSize),
@@ -56071,7 +56119,7 @@ fn __action1385<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1386<
+fn __action1387<
 >(
     __0: (TextSize, ast::Identifier, TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -56094,7 +56142,7 @@ fn __action1386<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1387<
+fn __action1388<
 >(
     __0: (TextSize, ast::Identifier, TextSize),
 ) -> ast::Arg
@@ -56113,7 +56161,7 @@ fn __action1387<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1388<
+fn __action1389<
 >(
     __0: (TextSize, core::option::Option<ast::Expr>, TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -56138,7 +56186,7 @@ fn __action1388<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1389<
+fn __action1390<
 >(
     __0: (TextSize, ast::Expr, TextSize),
 ) -> ast::Expr
@@ -56157,7 +56205,7 @@ fn __action1389<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1390<
+fn __action1391<
 >(
     __0: (TextSize, ast::Expr, TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -56178,7 +56226,7 @@ fn __action1390<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1391<
+fn __action1392<
 >(
     __0: (TextSize, Vec<ast::Expr>, TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -56199,7 +56247,7 @@ fn __action1391<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1392<
+fn __action1393<
 >(
     __0: (TextSize, Vec<ast::Expr>, TextSize),
 ) -> ast::Expr
@@ -56218,7 +56266,7 @@ fn __action1392<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1393<
+fn __action1394<
 >(
     __0: (TextSize, ast::Expr, TextSize),
     __1: (TextSize, ast::Operator, TextSize),
@@ -56241,7 +56289,7 @@ fn __action1393<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1394<
+fn __action1395<
 >(
     __0: (TextSize, ast::Expr, TextSize),
     __1: (TextSize, ast::Operator, TextSize),
@@ -56264,7 +56312,7 @@ fn __action1394<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1395<
+fn __action1396<
 >(
     __0: (TextSize, ast::Expr, TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -56291,7 +56339,7 @@ fn __action1395<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1396<
+fn __action1397<
 >(
     __0: (TextSize, ast::Expr, TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -56318,7 +56366,7 @@ fn __action1396<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1397<
+fn __action1398<
 >(
     __0: (TextSize, token::Tok, TextSize),
     __1: (TextSize, ast::Suite, TextSize),
@@ -56339,7 +56387,7 @@ fn __action1397<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1398<
+fn __action1399<
 >(
     __0: (TextSize, token::Tok, TextSize),
     __1: (TextSize, ast::Suite, TextSize),
@@ -56360,7 +56408,7 @@ fn __action1398<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1399<
+fn __action1400<
 >(
     __0: (TextSize, token::Tok, TextSize),
     __1: (TextSize, ast::Expr, TextSize),
@@ -56381,7 +56429,7 @@ fn __action1399<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1400<
+fn __action1401<
 >(
     __0: (TextSize, token::Tok, TextSize),
     __1: (TextSize, ast::Expr, TextSize),
@@ -56404,7 +56452,7 @@ fn __action1400<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1401<
+fn __action1402<
 >(
     __0: (TextSize, token::Tok, TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -56441,7 +56489,7 @@ fn __action1401<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1402<
+fn __action1403<
 >(
     __0: (TextSize, token::Tok, TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -56472,7 +56520,7 @@ fn __action1402<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1403<
+fn __action1404<
 >(
     __0: (TextSize, token::Tok, TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -56503,7 +56551,7 @@ fn __action1403<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1404<
+fn __action1405<
 >(
     __0: (TextSize, token::Tok, TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -56528,7 +56576,7 @@ fn __action1404<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1405<
+fn __action1406<
 >(
     __0: (TextSize, token::Tok, TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -56565,7 +56613,7 @@ fn __action1405<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1406<
+fn __action1407<
 >(
     __0: (TextSize, token::Tok, TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -56596,7 +56644,7 @@ fn __action1406<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1407<
+fn __action1408<
 >(
     __0: (TextSize, token::Tok, TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -56627,7 +56675,7 @@ fn __action1407<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1408<
+fn __action1409<
 >(
     __0: (TextSize, token::Tok, TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -56652,7 +56700,7 @@ fn __action1408<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1409<
+fn __action1410<
 >(
     __0: (TextSize, ast::Identifier, TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -56675,7 +56723,7 @@ fn __action1409<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1410<
+fn __action1411<
 >(
     __0: (TextSize, ast::Identifier, TextSize),
 ) -> ast::Arg
@@ -56694,7 +56742,7 @@ fn __action1410<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1411<
+fn __action1412<
 >(
     __0: (TextSize, ast::Identifier, TextSize),
 ) -> ast::Arg
@@ -56713,7 +56761,7 @@ fn __action1411<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1412<
+fn __action1413<
 >(
     __0: (TextSize, ast::Expr, TextSize),
 ) -> ast::Pattern
@@ -56732,7 +56780,7 @@ fn __action1412<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1413<
+fn __action1414<
 >(
     __0: (TextSize, ast::Expr, TextSize),
 ) -> ast::Withitem
@@ -56751,7 +56799,7 @@ fn __action1413<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1414<
+fn __action1415<
 >(
     __0: (TextSize, ast::Expr, TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -56774,7 +56822,7 @@ fn __action1414<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1415<
+fn __action1416<
 >(
     __0: (TextSize, ast::Expr, TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -56797,7 +56845,7 @@ fn __action1415<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1416<
+fn __action1417<
 >(
     __0: (TextSize, ast::Expr, TextSize),
 ) -> ast::Withitem
@@ -56816,7 +56864,7 @@ fn __action1416<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1417<
+fn __action1418<
 >(
     __0: (TextSize, ast::Expr, TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -56839,7 +56887,7 @@ fn __action1417<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1418<
+fn __action1419<
 >(
     __0: (TextSize, Vec<ast::Expr>, TextSize),
 ) -> Vec<ast::Withitem>
@@ -56858,7 +56906,7 @@ fn __action1418<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1419<
+fn __action1420<
 >(
     __0: (TextSize, ast::Expr, TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -56881,7 +56929,7 @@ fn __action1419<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1420<
+fn __action1421<
 >(
     __0: (TextSize, ast::Expr, TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -56904,7 +56952,7 @@ fn __action1420<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1421<
+fn __action1422<
 >(
     __0: (TextSize, token::Tok, TextSize),
     __1: (TextSize, core::option::Option<ast::Expr>, TextSize),
@@ -56925,7 +56973,7 @@ fn __action1421<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1422<
+fn __action1423<
 >(
     __0: (TextSize, token::Tok, TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -56948,7 +56996,7 @@ fn __action1422<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1423<
+fn __action1424<
 >(
     __0: (TextSize, Vec<ast::Expr>, TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -56956,7 +57004,7 @@ fn __action1423<
 {
     let __start0 = __0.0;
     let __end0 = __0.2;
-    let __temp0 = __action1418(
+    let __temp0 = __action1419(
         __0,
     );
     let __temp0 = (__start0, __temp0, __end0);
@@ -56967,7 +57015,7 @@ fn __action1423<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1424<
+fn __action1425<
 >(
     __0: (TextSize, token::Tok, TextSize),
     __1: (TextSize, Vec<ast::Expr>, TextSize),
@@ -56977,7 +57025,7 @@ fn __action1424<
 {
     let __start0 = __1.0;
     let __end0 = __1.2;
-    let __temp0 = __action1418(
+    let __temp0 = __action1419(
         __1,
     );
     let __temp0 = (__start0, __temp0, __end0);
@@ -56990,7 +57038,7 @@ fn __action1424<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1425<
+fn __action1426<
 >(
     __0: (TextSize, token::Tok, TextSize),
     __1: (TextSize, Vec<ast::Expr>, TextSize),
@@ -56999,7 +57047,7 @@ fn __action1425<
 {
     let __start0 = __1.0;
     let __end0 = __1.2;
-    let __temp0 = __action1418(
+    let __temp0 = __action1419(
         __1,
     );
     let __temp0 = (__start0, __temp0, __end0);
@@ -57011,7 +57059,7 @@ fn __action1425<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1426<
+fn __action1427<
 >(
     __0: (TextSize, Vec<ast::Expr>, TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -57019,7 +57067,7 @@ fn __action1426<
 {
     let __start0 = __0.0;
     let __end0 = __1.2;
-    let __temp0 = __action1423(
+    let __temp0 = __action1424(
         __0,
         __1,
     );
@@ -57030,7 +57078,7 @@ fn __action1426<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1427<
+fn __action1428<
 >(
     __0: (TextSize, token::Tok, TextSize),
     __1: (TextSize, Vec<ast::Expr>, TextSize),
@@ -57042,7 +57090,7 @@ fn __action1427<
 {
     let __start0 = __1.0;
     let __end0 = __2.2;
-    let __temp0 = __action1426(
+    let __temp0 = __action1427(
         __1,
         __2,
     );
@@ -57057,7 +57105,7 @@ fn __action1427<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1428<
+fn __action1429<
 >(
     __0: (TextSize, token::Tok, TextSize),
     __1: (TextSize, ast::Withitem, TextSize),
@@ -57082,7 +57130,7 @@ fn __action1428<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1429<
+fn __action1430<
 >(
     __0: (TextSize, token::Tok, TextSize),
     __1: (TextSize, Vec<ast::Expr>, TextSize),
@@ -57095,7 +57143,7 @@ fn __action1429<
 {
     let __start0 = __1.0;
     let __end0 = __2.2;
-    let __temp0 = __action1426(
+    let __temp0 = __action1427(
         __1,
         __2,
     );
@@ -57111,7 +57159,7 @@ fn __action1429<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1430<
+fn __action1431<
 >(
     __0: (TextSize, token::Tok, TextSize),
     __1: (TextSize, ast::Withitem, TextSize),
@@ -57138,7 +57186,7 @@ fn __action1430<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1431<
+fn __action1432<
 >(
     __0: (TextSize, token::Tok, TextSize),
     __1: (TextSize, Vec<ast::Expr>, TextSize),
@@ -57149,7 +57197,7 @@ fn __action1431<
 {
     let __start0 = __1.0;
     let __end0 = __2.2;
-    let __temp0 = __action1426(
+    let __temp0 = __action1427(
         __1,
         __2,
     );
@@ -57163,7 +57211,7 @@ fn __action1431<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1432<
+fn __action1433<
 >(
     __0: (TextSize, token::Tok, TextSize),
     __1: (TextSize, ast::Withitem, TextSize),
@@ -57186,7 +57234,7 @@ fn __action1432<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1433<
+fn __action1434<
 >(
     __0: (TextSize, token::Tok, TextSize),
     __1: (TextSize, Vec<ast::Expr>, TextSize),
@@ -57198,7 +57246,7 @@ fn __action1433<
 {
     let __start0 = __1.0;
     let __end0 = __2.2;
-    let __temp0 = __action1426(
+    let __temp0 = __action1427(
         __1,
         __2,
     );
@@ -57213,7 +57261,7 @@ fn __action1433<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1434<
+fn __action1435<
 >(
     __0: (TextSize, token::Tok, TextSize),
     __1: (TextSize, ast::Withitem, TextSize),
@@ -57238,7 +57286,7 @@ fn __action1434<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1435<
+fn __action1436<
 >(
     __0: (TextSize, (String, StringKind, bool), TextSize),
 ) -> alloc::vec::Vec<(TextSize, (String, StringKind, bool), TextSize)>
@@ -57255,7 +57303,7 @@ fn __action1435<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1436<
+fn __action1437<
 >(
     __0: (TextSize, alloc::vec::Vec<(TextSize, (String, StringKind, bool), TextSize)>, TextSize),
     __1: (TextSize, (String, StringKind, bool), TextSize),
@@ -57274,7 +57322,7 @@ fn __action1436<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1437<
+fn __action1438<
 >(
     __0: (TextSize, ast::Cmpop, TextSize),
     __1: (TextSize, ast::Expr, TextSize),
@@ -57293,7 +57341,7 @@ fn __action1437<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1438<
+fn __action1439<
 >(
     __0: (TextSize, alloc::vec::Vec<(ast::Cmpop, ast::Expr)>, TextSize),
     __1: (TextSize, ast::Cmpop, TextSize),
@@ -57314,7 +57362,7 @@ fn __action1438<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1439<
+fn __action1440<
 >(
     __0: (TextSize, ast::Expr, TextSize),
 ) -> core::option::Option<ast::Expr>
@@ -57331,7 +57379,7 @@ fn __action1439<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1440<
+fn __action1441<
 >(
     __0: (TextSize, token::Tok, TextSize),
     __1: (TextSize, ast::Pattern, TextSize),
@@ -57342,7 +57390,7 @@ fn __action1440<
 {
     let __start0 = __2.0;
     let __end0 = __2.2;
-    let __temp0 = __action1439(
+    let __temp0 = __action1440(
         __2,
     );
     let __temp0 = (__start0, __temp0, __end0);
@@ -57356,7 +57404,7 @@ fn __action1440<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1441<
+fn __action1442<
 >(
     __0: (TextSize, token::Tok, TextSize),
     __1: (TextSize, ast::Pattern, TextSize),
@@ -57381,7 +57429,7 @@ fn __action1441<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1442<
+fn __action1443<
 >(
     __0: (TextSize, ast::Arguments, TextSize),
 ) -> core::option::Option<ast::Arguments>
@@ -57398,7 +57446,7 @@ fn __action1442<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1443<
+fn __action1444<
 >(
     __0: (TextSize, token::Tok, TextSize),
     __1: (TextSize, ast::Arguments, TextSize),
@@ -57407,11 +57455,11 @@ fn __action1443<
 {
     let __start0 = __1.0;
     let __end0 = __1.2;
-    let __temp0 = __action1442(
+    let __temp0 = __action1443(
         __1,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1364(
+    __action1365(
         __0,
         __temp0,
         __2,
@@ -57419,7 +57467,7 @@ fn __action1443<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1444<
+fn __action1445<
 >(
     __0: (TextSize, token::Tok, TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -57432,7 +57480,7 @@ fn __action1444<
         &__end0,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1364(
+    __action1365(
         __0,
         __temp0,
         __1,
@@ -57440,7 +57488,7 @@ fn __action1444<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1445<
+fn __action1446<
 >(
     __0: (TextSize, ast::Expr, TextSize),
 ) -> ast::Stmt
@@ -57452,14 +57500,14 @@ fn __action1445<
         &__end0,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1233(
+    __action1234(
         __0,
         __temp0,
     )
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1446<
+fn __action1447<
 >(
     __0: (TextSize, ast::Expr, TextSize),
     __1: (TextSize, alloc::vec::Vec<ast::Expr>, TextSize),
@@ -57471,14 +57519,14 @@ fn __action1446<
         __1,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1233(
+    __action1234(
         __0,
         __temp0,
     )
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1447<
+fn __action1448<
 >(
     __0: (TextSize, ast::Expr, TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -57492,7 +57540,7 @@ fn __action1447<
         __3,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1235(
+    __action1236(
         __0,
         __1,
         __2,
@@ -57501,7 +57549,7 @@ fn __action1447<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1448<
+fn __action1449<
 >(
     __0: (TextSize, ast::Expr, TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -57515,7 +57563,7 @@ fn __action1448<
         &__end0,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1235(
+    __action1236(
         __0,
         __1,
         __2,
@@ -57524,7 +57572,7 @@ fn __action1448<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1449<
+fn __action1450<
 >(
     __0: (TextSize, (Option<(TextSize, TextSize, Option<ast::Identifier>)>, ast::Expr), TextSize),
 ) -> Vec<(Option<(TextSize, TextSize, Option<ast::Identifier>)>, ast::Expr)>
@@ -57541,7 +57589,7 @@ fn __action1449<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1450<
+fn __action1451<
 >(
     __lookbehind: &TextSize,
     __lookahead: &TextSize,
@@ -57560,7 +57608,7 @@ fn __action1450<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1451<
+fn __action1452<
 >(
     __0: (TextSize, alloc::vec::Vec<(Option<(TextSize, TextSize, Option<ast::Identifier>)>, ast::Expr)>, TextSize),
     __1: (TextSize, (Option<(TextSize, TextSize, Option<ast::Identifier>)>, ast::Expr), TextSize),
@@ -57579,7 +57627,7 @@ fn __action1451<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1452<
+fn __action1453<
 >(
     __0: (TextSize, alloc::vec::Vec<(Option<(TextSize, TextSize, Option<ast::Identifier>)>, ast::Expr)>, TextSize),
 ) -> Vec<(Option<(TextSize, TextSize, Option<ast::Identifier>)>, ast::Expr)>
@@ -57598,34 +57646,15 @@ fn __action1452<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1453<
+fn __action1454<
 >(
     __0: (TextSize, (Option<(TextSize, TextSize, Option<ast::Identifier>)>, ast::Expr), TextSize),
 ) -> Result<ArgumentList,__lalrpop_util::ParseError<TextSize,token::Tok,LexicalError>>
 {
     let __start0 = __0.0;
     let __end0 = __0.2;
-    let __temp0 = __action1449(
-        __0,
-    );
-    let __temp0 = (__start0, __temp0, __end0);
-    __action214(
-        __temp0,
-    )
-}
-
-#[allow(clippy::too_many_arguments)]
-fn __action1454<
->(
-    __lookbehind: &TextSize,
-    __lookahead: &TextSize,
-) -> Result<ArgumentList,__lalrpop_util::ParseError<TextSize,token::Tok,LexicalError>>
-{
-    let __start0 = *__lookbehind;
-    let __end0 = *__lookahead;
     let __temp0 = __action1450(
-        &__start0,
-        &__end0,
+        __0,
     );
     let __temp0 = (__start0, __temp0, __end0);
     __action214(
@@ -57636,15 +57665,15 @@ fn __action1454<
 #[allow(clippy::too_many_arguments)]
 fn __action1455<
 >(
-    __0: (TextSize, alloc::vec::Vec<(Option<(TextSize, TextSize, Option<ast::Identifier>)>, ast::Expr)>, TextSize),
-    __1: (TextSize, (Option<(TextSize, TextSize, Option<ast::Identifier>)>, ast::Expr), TextSize),
+    __lookbehind: &TextSize,
+    __lookahead: &TextSize,
 ) -> Result<ArgumentList,__lalrpop_util::ParseError<TextSize,token::Tok,LexicalError>>
 {
-    let __start0 = __0.0;
-    let __end0 = __1.2;
+    let __start0 = *__lookbehind;
+    let __end0 = *__lookahead;
     let __temp0 = __action1451(
-        __0,
-        __1,
+        &__start0,
+        &__end0,
     );
     let __temp0 = (__start0, __temp0, __end0);
     __action214(
@@ -57656,12 +57685,14 @@ fn __action1455<
 fn __action1456<
 >(
     __0: (TextSize, alloc::vec::Vec<(Option<(TextSize, TextSize, Option<ast::Identifier>)>, ast::Expr)>, TextSize),
+    __1: (TextSize, (Option<(TextSize, TextSize, Option<ast::Identifier>)>, ast::Expr), TextSize),
 ) -> Result<ArgumentList,__lalrpop_util::ParseError<TextSize,token::Tok,LexicalError>>
 {
     let __start0 = __0.0;
-    let __end0 = __0.2;
+    let __end0 = __1.2;
     let __temp0 = __action1452(
         __0,
+        __1,
     );
     let __temp0 = (__start0, __temp0, __end0);
     __action214(
@@ -57671,6 +57702,23 @@ fn __action1456<
 
 #[allow(clippy::too_many_arguments)]
 fn __action1457<
+>(
+    __0: (TextSize, alloc::vec::Vec<(Option<(TextSize, TextSize, Option<ast::Identifier>)>, ast::Expr)>, TextSize),
+) -> Result<ArgumentList,__lalrpop_util::ParseError<TextSize,token::Tok,LexicalError>>
+{
+    let __start0 = __0.0;
+    let __end0 = __0.2;
+    let __temp0 = __action1453(
+        __0,
+    );
+    let __temp0 = (__start0, __temp0, __end0);
+    __action214(
+        __temp0,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn __action1458<
 >(
     __0: (TextSize, ast::Pattern, TextSize),
 ) -> Vec<ast::Pattern>
@@ -57687,7 +57735,7 @@ fn __action1457<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1458<
+fn __action1459<
 >(
     __lookbehind: &TextSize,
     __lookahead: &TextSize,
@@ -57706,7 +57754,7 @@ fn __action1458<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1459<
+fn __action1460<
 >(
     __0: (TextSize, alloc::vec::Vec<ast::Pattern>, TextSize),
     __1: (TextSize, ast::Pattern, TextSize),
@@ -57725,7 +57773,7 @@ fn __action1459<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1460<
+fn __action1461<
 >(
     __0: (TextSize, alloc::vec::Vec<ast::Pattern>, TextSize),
 ) -> Vec<ast::Pattern>
@@ -57744,7 +57792,7 @@ fn __action1460<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1461<
+fn __action1462<
 >(
     __0: (TextSize, token::Tok, TextSize),
     __1: (TextSize, ast::Pattern, TextSize),
@@ -57753,11 +57801,11 @@ fn __action1461<
 {
     let __start0 = __1.0;
     let __end0 = __1.2;
-    let __temp0 = __action1457(
+    let __temp0 = __action1458(
         __1,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1379(
+    __action1380(
         __0,
         __temp0,
         __2,
@@ -57765,7 +57813,7 @@ fn __action1461<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1462<
+fn __action1463<
 >(
     __0: (TextSize, token::Tok, TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -57773,12 +57821,12 @@ fn __action1462<
 {
     let __start0 = __0.2;
     let __end0 = __1.0;
-    let __temp0 = __action1458(
+    let __temp0 = __action1459(
         &__start0,
         &__end0,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1379(
+    __action1380(
         __0,
         __temp0,
         __1,
@@ -57786,7 +57834,7 @@ fn __action1462<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1463<
+fn __action1464<
 >(
     __0: (TextSize, token::Tok, TextSize),
     __1: (TextSize, alloc::vec::Vec<ast::Pattern>, TextSize),
@@ -57796,12 +57844,12 @@ fn __action1463<
 {
     let __start0 = __1.0;
     let __end0 = __2.2;
-    let __temp0 = __action1459(
+    let __temp0 = __action1460(
         __1,
         __2,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1379(
+    __action1380(
         __0,
         __temp0,
         __3,
@@ -57809,7 +57857,7 @@ fn __action1463<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1464<
+fn __action1465<
 >(
     __0: (TextSize, token::Tok, TextSize),
     __1: (TextSize, alloc::vec::Vec<ast::Pattern>, TextSize),
@@ -57818,11 +57866,11 @@ fn __action1464<
 {
     let __start0 = __1.0;
     let __end0 = __1.2;
-    let __temp0 = __action1460(
+    let __temp0 = __action1461(
         __1,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1379(
+    __action1380(
         __0,
         __temp0,
         __2,
@@ -57830,7 +57878,7 @@ fn __action1464<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1465<
+fn __action1466<
 >(
     __0: (TextSize, ast::Expr, TextSize),
     __1: (TextSize, Vec<ast::Comprehension>, TextSize),
@@ -57842,14 +57890,14 @@ fn __action1465<
         __1,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1242(
+    __action1243(
         __0,
         __temp0,
     )
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1466<
+fn __action1467<
 >(
     __0: (TextSize, ast::Expr, TextSize),
 ) -> (Option<(TextSize, TextSize, Option<ast::Identifier>)>, ast::Expr)
@@ -57861,14 +57909,14 @@ fn __action1466<
         &__end0,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1242(
+    __action1243(
         __0,
         __temp0,
     )
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1467<
+fn __action1468<
 >(
     __0: (TextSize, token::Tok, TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -57884,7 +57932,7 @@ fn __action1467<
         &__end0,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1382(
+    __action1383(
         __0,
         __1,
         __2,
@@ -57895,7 +57943,7 @@ fn __action1467<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1468<
+fn __action1469<
 >(
     __0: (TextSize, token::Tok, TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -57911,7 +57959,7 @@ fn __action1468<
         __5,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1382(
+    __action1383(
         __0,
         __1,
         __2,
@@ -57922,7 +57970,7 @@ fn __action1468<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1469<
+fn __action1470<
 >(
     __0: (TextSize, token::Tok, TextSize),
     __1: (TextSize, ast::Expr, TextSize),
@@ -57937,7 +57985,7 @@ fn __action1469<
         &__end0,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1383(
+    __action1384(
         __0,
         __1,
         __2,
@@ -57947,7 +57995,7 @@ fn __action1469<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1470<
+fn __action1471<
 >(
     __0: (TextSize, token::Tok, TextSize),
     __1: (TextSize, ast::Expr, TextSize),
@@ -57962,7 +58010,7 @@ fn __action1470<
         __4,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1383(
+    __action1384(
         __0,
         __1,
         __2,
@@ -57972,7 +58020,7 @@ fn __action1470<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1471<
+fn __action1472<
 >(
     __0: (TextSize, token::Tok, TextSize),
     __1: (TextSize, ast::Identifier, TextSize),
@@ -58003,9 +58051,9 @@ fn __action1471<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1472<
+fn __action1473<
 >(
-    __0: (TextSize, alloc::vec::Vec<ast::Expr>, TextSize),
+    __0: (TextSize, alloc::vec::Vec<ast::Decorator>, TextSize),
     __1: (TextSize, token::Tok, TextSize),
     __2: (TextSize, ast::Identifier, TextSize),
     __3: (TextSize, token::Tok, TextSize),
@@ -58034,7 +58082,7 @@ fn __action1472<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1473<
+fn __action1474<
 >(
     __0: (TextSize, token::Tok, TextSize),
     __1: (TextSize, ast::Identifier, TextSize),
@@ -58059,9 +58107,9 @@ fn __action1473<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1474<
+fn __action1475<
 >(
-    __0: (TextSize, alloc::vec::Vec<ast::Expr>, TextSize),
+    __0: (TextSize, alloc::vec::Vec<ast::Decorator>, TextSize),
     __1: (TextSize, token::Tok, TextSize),
     __2: (TextSize, ast::Identifier, TextSize),
     __3: (TextSize, token::Tok, TextSize),
@@ -58084,7 +58132,7 @@ fn __action1474<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1475<
+fn __action1476<
 >(
     __0: (TextSize, token::Tok, TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -58117,9 +58165,9 @@ fn __action1475<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1476<
+fn __action1477<
 >(
-    __0: (TextSize, alloc::vec::Vec<ast::Expr>, TextSize),
+    __0: (TextSize, alloc::vec::Vec<ast::Decorator>, TextSize),
     __1: (TextSize, token::Tok, TextSize),
     __2: (TextSize, token::Tok, TextSize),
     __3: (TextSize, ast::Identifier, TextSize),
@@ -58150,7 +58198,7 @@ fn __action1476<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1477<
+fn __action1478<
 >(
     __0: (TextSize, token::Tok, TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -58179,9 +58227,9 @@ fn __action1477<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1478<
+fn __action1479<
 >(
-    __0: (TextSize, alloc::vec::Vec<ast::Expr>, TextSize),
+    __0: (TextSize, alloc::vec::Vec<ast::Decorator>, TextSize),
     __1: (TextSize, token::Tok, TextSize),
     __2: (TextSize, token::Tok, TextSize),
     __3: (TextSize, ast::Identifier, TextSize),
@@ -58208,7 +58256,7 @@ fn __action1478<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1479<
+fn __action1480<
 >(
     __0: (TextSize, token::Tok, TextSize),
     __1: (TextSize, ast::Identifier, TextSize),
@@ -58239,9 +58287,9 @@ fn __action1479<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1480<
+fn __action1481<
 >(
-    __0: (TextSize, alloc::vec::Vec<ast::Expr>, TextSize),
+    __0: (TextSize, alloc::vec::Vec<ast::Decorator>, TextSize),
     __1: (TextSize, token::Tok, TextSize),
     __2: (TextSize, ast::Identifier, TextSize),
     __3: (TextSize, ast::Arguments, TextSize),
@@ -58270,7 +58318,7 @@ fn __action1480<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1481<
+fn __action1482<
 >(
     __0: (TextSize, token::Tok, TextSize),
     __1: (TextSize, ast::Identifier, TextSize),
@@ -58297,9 +58345,9 @@ fn __action1481<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1482<
+fn __action1483<
 >(
-    __0: (TextSize, alloc::vec::Vec<ast::Expr>, TextSize),
+    __0: (TextSize, alloc::vec::Vec<ast::Decorator>, TextSize),
     __1: (TextSize, token::Tok, TextSize),
     __2: (TextSize, ast::Identifier, TextSize),
     __3: (TextSize, ast::Arguments, TextSize),
@@ -58324,7 +58372,7 @@ fn __action1482<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1483<
+fn __action1484<
 >(
     __0: (TextSize, token::Tok, TextSize),
     __1: (TextSize, Vec<(Option<Box<ast::Expr>>, ast::Expr)>, TextSize),
@@ -58341,27 +58389,6 @@ fn __action1483<
         __0,
         __temp0,
         __2,
-    )
-}
-
-#[allow(clippy::too_many_arguments)]
-fn __action1484<
->(
-    __0: (TextSize, token::Tok, TextSize),
-    __1: (TextSize, token::Tok, TextSize),
-) -> ast::Expr
-{
-    let __start0 = __0.2;
-    let __end0 = __1.0;
-    let __temp0 = __action522(
-        &__start0,
-        &__end0,
-    );
-    let __temp0 = (__start0, __temp0, __end0);
-    __action1172(
-        __0,
-        __temp0,
-        __1,
     )
 }
 
@@ -58369,6 +58396,27 @@ fn __action1484<
 fn __action1485<
 >(
     __0: (TextSize, token::Tok, TextSize),
+    __1: (TextSize, token::Tok, TextSize),
+) -> ast::Expr
+{
+    let __start0 = __0.2;
+    let __end0 = __1.0;
+    let __temp0 = __action522(
+        &__start0,
+        &__end0,
+    );
+    let __temp0 = (__start0, __temp0, __end0);
+    __action1172(
+        __0,
+        __temp0,
+        __1,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn __action1486<
+>(
+    __0: (TextSize, token::Tok, TextSize),
     __1: (TextSize, Vec<(Option<Box<ast::Expr>>, ast::Expr)>, TextSize),
     __2: (TextSize, token::Tok, TextSize),
 ) -> ast::Expr
@@ -58387,7 +58435,7 @@ fn __action1485<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1486<
+fn __action1487<
 >(
     __0: (TextSize, token::Tok, TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -58408,7 +58456,7 @@ fn __action1486<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1487<
+fn __action1488<
 >(
     __0: (TextSize, ast::Identifier, TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -58417,27 +58465,10 @@ fn __action1487<
 {
     let __start0 = __0.0;
     let __end0 = __2.2;
-    let __temp0 = __action1251(
+    let __temp0 = __action1252(
         __0,
         __1,
         __2,
-    );
-    let __temp0 = (__start0, __temp0, __end0);
-    __action347(
-        __temp0,
-    )
-}
-
-#[allow(clippy::too_many_arguments)]
-fn __action1488<
->(
-    __0: (TextSize, ast::Identifier, TextSize),
-) -> Vec<ast::Alias>
-{
-    let __start0 = __0.0;
-    let __end0 = __0.2;
-    let __temp0 = __action1252(
-        __0,
     );
     let __temp0 = (__start0, __temp0, __end0);
     __action347(
@@ -58448,24 +58479,16 @@ fn __action1488<
 #[allow(clippy::too_many_arguments)]
 fn __action1489<
 >(
-    __0: (TextSize, Vec<ast::Alias>, TextSize),
-    __1: (TextSize, token::Tok, TextSize),
-    __2: (TextSize, ast::Identifier, TextSize),
-    __3: (TextSize, token::Tok, TextSize),
-    __4: (TextSize, ast::Identifier, TextSize),
+    __0: (TextSize, ast::Identifier, TextSize),
 ) -> Vec<ast::Alias>
 {
-    let __start0 = __2.0;
-    let __end0 = __4.2;
-    let __temp0 = __action1251(
-        __2,
-        __3,
-        __4,
+    let __start0 = __0.0;
+    let __end0 = __0.2;
+    let __temp0 = __action1253(
+        __0,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action348(
-        __0,
-        __1,
+    __action347(
         __temp0,
     )
 }
@@ -58476,12 +58499,16 @@ fn __action1490<
     __0: (TextSize, Vec<ast::Alias>, TextSize),
     __1: (TextSize, token::Tok, TextSize),
     __2: (TextSize, ast::Identifier, TextSize),
+    __3: (TextSize, token::Tok, TextSize),
+    __4: (TextSize, ast::Identifier, TextSize),
 ) -> Vec<ast::Alias>
 {
     let __start0 = __2.0;
-    let __end0 = __2.2;
+    let __end0 = __4.2;
     let __temp0 = __action1252(
         __2,
+        __3,
+        __4,
     );
     let __temp0 = (__start0, __temp0, __end0);
     __action348(
@@ -58494,6 +58521,27 @@ fn __action1490<
 #[allow(clippy::too_many_arguments)]
 fn __action1491<
 >(
+    __0: (TextSize, Vec<ast::Alias>, TextSize),
+    __1: (TextSize, token::Tok, TextSize),
+    __2: (TextSize, ast::Identifier, TextSize),
+) -> Vec<ast::Alias>
+{
+    let __start0 = __2.0;
+    let __end0 = __2.2;
+    let __temp0 = __action1253(
+        __2,
+    );
+    let __temp0 = (__start0, __temp0, __end0);
+    __action348(
+        __0,
+        __1,
+        __temp0,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn __action1492<
+>(
     __0: (TextSize, ast::Identifier, TextSize),
     __1: (TextSize, token::Tok, TextSize),
     __2: (TextSize, ast::Identifier, TextSize),
@@ -58501,7 +58549,7 @@ fn __action1491<
 {
     let __start0 = __0.0;
     let __end0 = __2.2;
-    let __temp0 = __action1253(
+    let __temp0 = __action1254(
         __0,
         __1,
         __2,
@@ -58513,14 +58561,14 @@ fn __action1491<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1492<
+fn __action1493<
 >(
     __0: (TextSize, ast::Identifier, TextSize),
 ) -> Vec<ast::Alias>
 {
     let __start0 = __0.0;
     let __end0 = __0.2;
-    let __temp0 = __action1254(
+    let __temp0 = __action1255(
         __0,
     );
     let __temp0 = (__start0, __temp0, __end0);
@@ -58530,7 +58578,7 @@ fn __action1492<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1493<
+fn __action1494<
 >(
     __0: (TextSize, Vec<ast::Alias>, TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -58541,7 +58589,7 @@ fn __action1493<
 {
     let __start0 = __2.0;
     let __end0 = __4.2;
-    let __temp0 = __action1253(
+    let __temp0 = __action1254(
         __2,
         __3,
         __4,
@@ -58555,7 +58603,7 @@ fn __action1493<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1494<
+fn __action1495<
 >(
     __0: (TextSize, Vec<ast::Alias>, TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -58564,7 +58612,7 @@ fn __action1494<
 {
     let __start0 = __2.0;
     let __end0 = __2.2;
-    let __temp0 = __action1254(
+    let __temp0 = __action1255(
         __2,
     );
     let __temp0 = (__start0, __temp0, __end0);
@@ -58576,7 +58624,7 @@ fn __action1494<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1495<
+fn __action1496<
 >(
     __0: (TextSize, ast::Identifier, TextSize),
 ) -> (Option<ast::Int>, Option<ast::Identifier>)
@@ -58595,7 +58643,7 @@ fn __action1495<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1496<
+fn __action1497<
 >(
     __0: (TextSize, alloc::vec::Vec<ast::Int>, TextSize),
     __1: (TextSize, ast::Identifier, TextSize),
@@ -58614,7 +58662,7 @@ fn __action1496<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1497<
+fn __action1498<
 >(
     __0: (TextSize, token::Tok, TextSize),
     __1: (TextSize, Vec<ast::Expr>, TextSize),
@@ -58631,27 +58679,6 @@ fn __action1497<
         __0,
         __temp0,
         __2,
-    )
-}
-
-#[allow(clippy::too_many_arguments)]
-fn __action1498<
->(
-    __0: (TextSize, token::Tok, TextSize),
-    __1: (TextSize, token::Tok, TextSize),
-) -> ast::Expr
-{
-    let __start0 = __0.2;
-    let __end0 = __1.0;
-    let __temp0 = __action530(
-        &__start0,
-        &__end0,
-    );
-    let __temp0 = (__start0, __temp0, __end0);
-    __action1157(
-        __0,
-        __temp0,
-        __1,
     )
 }
 
@@ -58659,6 +58686,27 @@ fn __action1498<
 fn __action1499<
 >(
     __0: (TextSize, token::Tok, TextSize),
+    __1: (TextSize, token::Tok, TextSize),
+) -> ast::Expr
+{
+    let __start0 = __0.2;
+    let __end0 = __1.0;
+    let __temp0 = __action530(
+        &__start0,
+        &__end0,
+    );
+    let __temp0 = (__start0, __temp0, __end0);
+    __action1157(
+        __0,
+        __temp0,
+        __1,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn __action1500<
+>(
+    __0: (TextSize, token::Tok, TextSize),
     __1: (TextSize, Vec<ast::Expr>, TextSize),
     __2: (TextSize, token::Tok, TextSize),
 ) -> ast::Expr
@@ -58677,7 +58725,7 @@ fn __action1499<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1500<
+fn __action1501<
 >(
     __0: (TextSize, token::Tok, TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -58698,7 +58746,7 @@ fn __action1500<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1501<
+fn __action1502<
 >(
     __0: (TextSize, Vec<(ast::Arg, Option<ast::Expr>)>, TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -58715,7 +58763,7 @@ fn __action1501<
         __0,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1288(
+    __action1289(
         __temp0,
         __1,
         __2,
@@ -58727,7 +58775,7 @@ fn __action1501<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1502<
+fn __action1503<
 >(
     __0: (TextSize, Vec<(ast::Arg, Option<ast::Expr>)>, TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -58748,7 +58796,7 @@ fn __action1502<
         __2,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1288(
+    __action1289(
         __temp0,
         __3,
         __4,
@@ -58760,7 +58808,7 @@ fn __action1502<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1503<
+fn __action1504<
 >(
     __0: (TextSize, Vec<(ast::Arg, Option<ast::Expr>)>, TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -58783,7 +58831,7 @@ fn __action1503<
         __3,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1288(
+    __action1289(
         __temp0,
         __4,
         __5,
@@ -58795,7 +58843,7 @@ fn __action1503<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1504<
+fn __action1505<
 >(
     __0: (TextSize, Vec<(ast::Arg, Option<ast::Expr>)>, TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -58811,7 +58859,7 @@ fn __action1504<
         __0,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1289(
+    __action1290(
         __temp0,
         __1,
         __2,
@@ -58822,7 +58870,7 @@ fn __action1504<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1505<
+fn __action1506<
 >(
     __0: (TextSize, Vec<(ast::Arg, Option<ast::Expr>)>, TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -58842,7 +58890,7 @@ fn __action1505<
         __2,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1289(
+    __action1290(
         __temp0,
         __3,
         __4,
@@ -58853,7 +58901,7 @@ fn __action1505<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1506<
+fn __action1507<
 >(
     __0: (TextSize, Vec<(ast::Arg, Option<ast::Expr>)>, TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -58875,7 +58923,7 @@ fn __action1506<
         __3,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1289(
+    __action1290(
         __temp0,
         __4,
         __5,
@@ -58886,7 +58934,7 @@ fn __action1506<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1507<
+fn __action1508<
 >(
     __0: (TextSize, Vec<(ast::Arg, Option<ast::Expr>)>, TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -58904,7 +58952,7 @@ fn __action1507<
         __0,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1290(
+    __action1291(
         __temp0,
         __1,
         __2,
@@ -58917,7 +58965,7 @@ fn __action1507<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1508<
+fn __action1509<
 >(
     __0: (TextSize, Vec<(ast::Arg, Option<ast::Expr>)>, TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -58939,7 +58987,7 @@ fn __action1508<
         __2,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1290(
+    __action1291(
         __temp0,
         __3,
         __4,
@@ -58948,43 +58996,6 @@ fn __action1508<
         __7,
         __8,
         __9,
-    )
-}
-
-#[allow(clippy::too_many_arguments)]
-fn __action1509<
->(
-    __0: (TextSize, Vec<(ast::Arg, Option<ast::Expr>)>, TextSize),
-    __1: (TextSize, token::Tok, TextSize),
-    __2: (TextSize, token::Tok, TextSize),
-    __3: (TextSize, alloc::vec::Vec<(ast::Arg, Option<ast::Expr>)>, TextSize),
-    __4: (TextSize, token::Tok, TextSize),
-    __5: (TextSize, token::Tok, TextSize),
-    __6: (TextSize, ast::Arg, TextSize),
-    __7: (TextSize, alloc::vec::Vec<(ast::Arg, Option<ast::Expr>)>, TextSize),
-    __8: (TextSize, token::Tok, TextSize),
-    __9: (TextSize, Option<Box<ast::Arg>>, TextSize),
-    __10: (TextSize, token::Tok, TextSize),
-) -> Result<ast::Arguments,__lalrpop_util::ParseError<TextSize,token::Tok,LexicalError>>
-{
-    let __start0 = __0.0;
-    let __end0 = __3.2;
-    let __temp0 = __action659(
-        __0,
-        __1,
-        __2,
-        __3,
-    );
-    let __temp0 = (__start0, __temp0, __end0);
-    __action1290(
-        __temp0,
-        __4,
-        __5,
-        __6,
-        __7,
-        __8,
-        __9,
-        __10,
     )
 }
 
@@ -58996,6 +59007,43 @@ fn __action1510<
     __2: (TextSize, token::Tok, TextSize),
     __3: (TextSize, alloc::vec::Vec<(ast::Arg, Option<ast::Expr>)>, TextSize),
     __4: (TextSize, token::Tok, TextSize),
+    __5: (TextSize, token::Tok, TextSize),
+    __6: (TextSize, ast::Arg, TextSize),
+    __7: (TextSize, alloc::vec::Vec<(ast::Arg, Option<ast::Expr>)>, TextSize),
+    __8: (TextSize, token::Tok, TextSize),
+    __9: (TextSize, Option<Box<ast::Arg>>, TextSize),
+    __10: (TextSize, token::Tok, TextSize),
+) -> Result<ast::Arguments,__lalrpop_util::ParseError<TextSize,token::Tok,LexicalError>>
+{
+    let __start0 = __0.0;
+    let __end0 = __3.2;
+    let __temp0 = __action659(
+        __0,
+        __1,
+        __2,
+        __3,
+    );
+    let __temp0 = (__start0, __temp0, __end0);
+    __action1291(
+        __temp0,
+        __4,
+        __5,
+        __6,
+        __7,
+        __8,
+        __9,
+        __10,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn __action1511<
+>(
+    __0: (TextSize, Vec<(ast::Arg, Option<ast::Expr>)>, TextSize),
+    __1: (TextSize, token::Tok, TextSize),
+    __2: (TextSize, token::Tok, TextSize),
+    __3: (TextSize, alloc::vec::Vec<(ast::Arg, Option<ast::Expr>)>, TextSize),
+    __4: (TextSize, token::Tok, TextSize),
     __5: (TextSize, Option<Box<ast::Arg>>, TextSize),
     __6: (TextSize, token::Tok, TextSize),
 ) -> Result<ast::Arguments,__lalrpop_util::ParseError<TextSize,token::Tok,LexicalError>>
@@ -59006,7 +59054,7 @@ fn __action1510<
         __0,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1291(
+    __action1292(
         __temp0,
         __1,
         __2,
@@ -59018,7 +59066,7 @@ fn __action1510<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1511<
+fn __action1512<
 >(
     __0: (TextSize, Vec<(ast::Arg, Option<ast::Expr>)>, TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -59039,7 +59087,7 @@ fn __action1511<
         __2,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1291(
+    __action1292(
         __temp0,
         __3,
         __4,
@@ -59051,7 +59099,7 @@ fn __action1511<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1512<
+fn __action1513<
 >(
     __0: (TextSize, Vec<(ast::Arg, Option<ast::Expr>)>, TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -59074,7 +59122,7 @@ fn __action1512<
         __3,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1291(
+    __action1292(
         __temp0,
         __4,
         __5,
@@ -59086,7 +59134,7 @@ fn __action1512<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1513<
+fn __action1514<
 >(
     __0: (TextSize, Vec<(ast::Arg, Option<ast::Expr>)>, TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -59101,7 +59149,7 @@ fn __action1513<
         __0,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1292(
+    __action1293(
         __temp0,
         __1,
         __2,
@@ -59111,7 +59159,7 @@ fn __action1513<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1514<
+fn __action1515<
 >(
     __0: (TextSize, Vec<(ast::Arg, Option<ast::Expr>)>, TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -59130,7 +59178,7 @@ fn __action1514<
         __2,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1292(
+    __action1293(
         __temp0,
         __3,
         __4,
@@ -59140,7 +59188,7 @@ fn __action1514<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1515<
+fn __action1516<
 >(
     __0: (TextSize, Vec<(ast::Arg, Option<ast::Expr>)>, TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -59161,7 +59209,7 @@ fn __action1515<
         __3,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1292(
+    __action1293(
         __temp0,
         __4,
         __5,
@@ -59171,7 +59219,7 @@ fn __action1515<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1516<
+fn __action1517<
 >(
     __0: (TextSize, Vec<(ast::Arg, Option<ast::Expr>)>, TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -59185,7 +59233,7 @@ fn __action1516<
         __0,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1293(
+    __action1294(
         __temp0,
         __1,
         __2,
@@ -59194,7 +59242,7 @@ fn __action1516<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1517<
+fn __action1518<
 >(
     __0: (TextSize, Vec<(ast::Arg, Option<ast::Expr>)>, TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -59212,7 +59260,7 @@ fn __action1517<
         __2,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1293(
+    __action1294(
         __temp0,
         __3,
         __4,
@@ -59221,7 +59269,7 @@ fn __action1517<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1518<
+fn __action1519<
 >(
     __0: (TextSize, Vec<(ast::Arg, Option<ast::Expr>)>, TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -59241,7 +59289,7 @@ fn __action1518<
         __3,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1293(
+    __action1294(
         __temp0,
         __4,
         __5,
@@ -59250,7 +59298,7 @@ fn __action1518<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1519<
+fn __action1520<
 >(
     __0: (TextSize, Vec<(ast::Arg, Option<ast::Expr>)>, TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -59266,7 +59314,7 @@ fn __action1519<
         __0,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1294(
+    __action1295(
         __temp0,
         __1,
         __2,
@@ -59277,7 +59325,7 @@ fn __action1519<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1520<
+fn __action1521<
 >(
     __0: (TextSize, Vec<(ast::Arg, Option<ast::Expr>)>, TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -59297,7 +59345,7 @@ fn __action1520<
         __2,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1294(
+    __action1295(
         __temp0,
         __3,
         __4,
@@ -59308,7 +59356,7 @@ fn __action1520<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1521<
+fn __action1522<
 >(
     __0: (TextSize, Vec<(ast::Arg, Option<ast::Expr>)>, TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -59330,7 +59378,7 @@ fn __action1521<
         __3,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1294(
+    __action1295(
         __temp0,
         __4,
         __5,
@@ -59341,7 +59389,7 @@ fn __action1521<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1522<
+fn __action1523<
 >(
     __0: (TextSize, Vec<(ast::Arg, Option<ast::Expr>)>, TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -59356,7 +59404,7 @@ fn __action1522<
         __0,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1295(
+    __action1296(
         __temp0,
         __1,
         __2,
@@ -59366,7 +59414,7 @@ fn __action1522<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1523<
+fn __action1524<
 >(
     __0: (TextSize, Vec<(ast::Arg, Option<ast::Expr>)>, TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -59385,7 +59433,7 @@ fn __action1523<
         __2,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1295(
+    __action1296(
         __temp0,
         __3,
         __4,
@@ -59395,7 +59443,7 @@ fn __action1523<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1524<
+fn __action1525<
 >(
     __0: (TextSize, Vec<(ast::Arg, Option<ast::Expr>)>, TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -59416,7 +59464,7 @@ fn __action1524<
         __3,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1295(
+    __action1296(
         __temp0,
         __4,
         __5,
@@ -59426,7 +59474,7 @@ fn __action1524<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1525<
+fn __action1526<
 >(
     __0: (TextSize, Vec<(ast::Arg, Option<ast::Expr>)>, TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -59438,14 +59486,14 @@ fn __action1525<
         __0,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1296(
+    __action1297(
         __temp0,
         __1,
     )
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1526<
+fn __action1527<
 >(
     __0: (TextSize, Vec<(ast::Arg, Option<ast::Expr>)>, TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -59461,14 +59509,14 @@ fn __action1526<
         __2,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1296(
+    __action1297(
         __temp0,
         __3,
     )
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1527<
+fn __action1528<
 >(
     __0: (TextSize, Vec<(ast::Arg, Option<ast::Expr>)>, TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -59486,14 +59534,14 @@ fn __action1527<
         __3,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1296(
+    __action1297(
         __temp0,
         __4,
     )
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1528<
+fn __action1529<
 >(
     __0: (TextSize, Vec<(ast::Arg, Option<ast::Expr>)>, TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -59509,7 +59557,7 @@ fn __action1528<
         __0,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1297(
+    __action1298(
         __temp0,
         __1,
         __2,
@@ -59520,7 +59568,7 @@ fn __action1528<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1529<
+fn __action1530<
 >(
     __0: (TextSize, Vec<(ast::Arg, Option<ast::Expr>)>, TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -59540,7 +59588,7 @@ fn __action1529<
         __2,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1297(
+    __action1298(
         __temp0,
         __3,
         __4,
@@ -59551,7 +59599,7 @@ fn __action1529<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1530<
+fn __action1531<
 >(
     __0: (TextSize, Vec<(ast::Arg, Option<ast::Expr>)>, TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -59573,7 +59621,7 @@ fn __action1530<
         __3,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1297(
+    __action1298(
         __temp0,
         __4,
         __5,
@@ -59584,7 +59632,7 @@ fn __action1530<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1531<
+fn __action1532<
 >(
     __0: (TextSize, Vec<(ast::Arg, Option<ast::Expr>)>, TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -59599,7 +59647,7 @@ fn __action1531<
         __0,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1298(
+    __action1299(
         __temp0,
         __1,
         __2,
@@ -59609,7 +59657,7 @@ fn __action1531<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1532<
+fn __action1533<
 >(
     __0: (TextSize, Vec<(ast::Arg, Option<ast::Expr>)>, TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -59628,7 +59676,7 @@ fn __action1532<
         __2,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1298(
+    __action1299(
         __temp0,
         __3,
         __4,
@@ -59638,7 +59686,7 @@ fn __action1532<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1533<
+fn __action1534<
 >(
     __0: (TextSize, Vec<(ast::Arg, Option<ast::Expr>)>, TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -59659,7 +59707,7 @@ fn __action1533<
         __3,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1298(
+    __action1299(
         __temp0,
         __4,
         __5,
@@ -59669,7 +59717,7 @@ fn __action1533<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1534<
+fn __action1535<
 >(
     __0: (TextSize, Vec<(ast::Arg, Option<ast::Expr>)>, TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -59686,7 +59734,7 @@ fn __action1534<
         __0,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1299(
+    __action1300(
         __temp0,
         __1,
         __2,
@@ -59698,7 +59746,7 @@ fn __action1534<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1535<
+fn __action1536<
 >(
     __0: (TextSize, Vec<(ast::Arg, Option<ast::Expr>)>, TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -59719,7 +59767,7 @@ fn __action1535<
         __2,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1299(
+    __action1300(
         __temp0,
         __3,
         __4,
@@ -59731,7 +59779,7 @@ fn __action1535<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1536<
+fn __action1537<
 >(
     __0: (TextSize, Vec<(ast::Arg, Option<ast::Expr>)>, TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -59754,7 +59802,7 @@ fn __action1536<
         __3,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1299(
+    __action1300(
         __temp0,
         __4,
         __5,
@@ -59766,7 +59814,7 @@ fn __action1536<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1537<
+fn __action1538<
 >(
     __0: (TextSize, Vec<(ast::Arg, Option<ast::Expr>)>, TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -59782,7 +59830,7 @@ fn __action1537<
         __0,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1300(
+    __action1301(
         __temp0,
         __1,
         __2,
@@ -59793,7 +59841,7 @@ fn __action1537<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1538<
+fn __action1539<
 >(
     __0: (TextSize, Vec<(ast::Arg, Option<ast::Expr>)>, TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -59813,7 +59861,7 @@ fn __action1538<
         __2,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1300(
+    __action1301(
         __temp0,
         __3,
         __4,
@@ -59824,7 +59872,7 @@ fn __action1538<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1539<
+fn __action1540<
 >(
     __0: (TextSize, Vec<(ast::Arg, Option<ast::Expr>)>, TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -59846,7 +59894,7 @@ fn __action1539<
         __3,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1300(
+    __action1301(
         __temp0,
         __4,
         __5,
@@ -59857,7 +59905,7 @@ fn __action1539<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1540<
+fn __action1541<
 >(
     __0: (TextSize, Vec<(ast::Arg, Option<ast::Expr>)>, TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -59871,7 +59919,7 @@ fn __action1540<
         __0,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1301(
+    __action1302(
         __temp0,
         __1,
         __2,
@@ -59880,7 +59928,7 @@ fn __action1540<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1541<
+fn __action1542<
 >(
     __0: (TextSize, Vec<(ast::Arg, Option<ast::Expr>)>, TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -59898,7 +59946,7 @@ fn __action1541<
         __2,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1301(
+    __action1302(
         __temp0,
         __3,
         __4,
@@ -59907,7 +59955,7 @@ fn __action1541<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1542<
+fn __action1543<
 >(
     __0: (TextSize, Vec<(ast::Arg, Option<ast::Expr>)>, TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -59927,7 +59975,7 @@ fn __action1542<
         __3,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1301(
+    __action1302(
         __temp0,
         __4,
         __5,
@@ -59936,7 +59984,7 @@ fn __action1542<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1543<
+fn __action1544<
 >(
     __0: (TextSize, Vec<(ast::Arg, Option<ast::Expr>)>, TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -59949,7 +59997,7 @@ fn __action1543<
         __0,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1302(
+    __action1303(
         __temp0,
         __1,
         __2,
@@ -59957,7 +60005,7 @@ fn __action1543<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1544<
+fn __action1545<
 >(
     __0: (TextSize, Vec<(ast::Arg, Option<ast::Expr>)>, TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -59974,7 +60022,7 @@ fn __action1544<
         __2,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1302(
+    __action1303(
         __temp0,
         __3,
         __4,
@@ -59982,7 +60030,7 @@ fn __action1544<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1545<
+fn __action1546<
 >(
     __0: (TextSize, Vec<(ast::Arg, Option<ast::Expr>)>, TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -60001,7 +60049,7 @@ fn __action1545<
         __3,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1302(
+    __action1303(
         __temp0,
         __4,
         __5,
@@ -60009,7 +60057,7 @@ fn __action1545<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1546<
+fn __action1547<
 >(
     __0: (TextSize, Vec<(ast::Arg, Option<ast::Expr>)>, TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -60024,7 +60072,7 @@ fn __action1546<
         __0,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1303(
+    __action1304(
         __temp0,
         __1,
         __2,
@@ -60034,7 +60082,7 @@ fn __action1546<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1547<
+fn __action1548<
 >(
     __0: (TextSize, Vec<(ast::Arg, Option<ast::Expr>)>, TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -60053,7 +60101,7 @@ fn __action1547<
         __2,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1303(
+    __action1304(
         __temp0,
         __3,
         __4,
@@ -60063,7 +60111,7 @@ fn __action1547<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1548<
+fn __action1549<
 >(
     __0: (TextSize, Vec<(ast::Arg, Option<ast::Expr>)>, TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -60084,7 +60132,7 @@ fn __action1548<
         __3,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1303(
+    __action1304(
         __temp0,
         __4,
         __5,
@@ -60094,7 +60142,7 @@ fn __action1548<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1549<
+fn __action1550<
 >(
     __0: (TextSize, Vec<(ast::Arg, Option<ast::Expr>)>, TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -60108,7 +60156,7 @@ fn __action1549<
         __0,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1304(
+    __action1305(
         __temp0,
         __1,
         __2,
@@ -60117,7 +60165,7 @@ fn __action1549<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1550<
+fn __action1551<
 >(
     __0: (TextSize, Vec<(ast::Arg, Option<ast::Expr>)>, TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -60135,7 +60183,7 @@ fn __action1550<
         __2,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1304(
+    __action1305(
         __temp0,
         __3,
         __4,
@@ -60144,7 +60192,7 @@ fn __action1550<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1551<
+fn __action1552<
 >(
     __0: (TextSize, Vec<(ast::Arg, Option<ast::Expr>)>, TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -60164,7 +60212,7 @@ fn __action1551<
         __3,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1304(
+    __action1305(
         __temp0,
         __4,
         __5,
@@ -60173,7 +60221,7 @@ fn __action1551<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1552<
+fn __action1553<
 >(
     __0: (TextSize, Vec<(ast::Arg, Option<ast::Expr>)>, TextSize),
 ) -> Result<ast::Arguments,__lalrpop_util::ParseError<TextSize,token::Tok,LexicalError>>
@@ -60184,13 +60232,13 @@ fn __action1552<
         __0,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1305(
+    __action1306(
         __temp0,
     )
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1553<
+fn __action1554<
 >(
     __0: (TextSize, Vec<(ast::Arg, Option<ast::Expr>)>, TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -60205,13 +60253,13 @@ fn __action1553<
         __2,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1305(
+    __action1306(
         __temp0,
     )
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1554<
+fn __action1555<
 >(
     __0: (TextSize, Vec<(ast::Arg, Option<ast::Expr>)>, TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -60228,13 +60276,13 @@ fn __action1554<
         __3,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1305(
+    __action1306(
         __temp0,
     )
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1555<
+fn __action1556<
 >(
     __0: (TextSize, Vec<(ast::Arg, Option<ast::Expr>)>, TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -60248,7 +60296,7 @@ fn __action1555<
         __0,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1306(
+    __action1307(
         __temp0,
         __1,
         __2,
@@ -60257,7 +60305,7 @@ fn __action1555<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1556<
+fn __action1557<
 >(
     __0: (TextSize, Vec<(ast::Arg, Option<ast::Expr>)>, TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -60275,7 +60323,7 @@ fn __action1556<
         __2,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1306(
+    __action1307(
         __temp0,
         __3,
         __4,
@@ -60284,7 +60332,7 @@ fn __action1556<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1557<
+fn __action1558<
 >(
     __0: (TextSize, Vec<(ast::Arg, Option<ast::Expr>)>, TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -60304,7 +60352,7 @@ fn __action1557<
         __3,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1306(
+    __action1307(
         __temp0,
         __4,
         __5,
@@ -60313,7 +60361,7 @@ fn __action1557<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1558<
+fn __action1559<
 >(
     __0: (TextSize, Vec<(ast::Arg, Option<ast::Expr>)>, TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -60326,7 +60374,7 @@ fn __action1558<
         __0,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1307(
+    __action1308(
         __temp0,
         __1,
         __2,
@@ -60334,7 +60382,7 @@ fn __action1558<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1559<
+fn __action1560<
 >(
     __0: (TextSize, Vec<(ast::Arg, Option<ast::Expr>)>, TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -60351,7 +60399,7 @@ fn __action1559<
         __2,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1307(
+    __action1308(
         __temp0,
         __3,
         __4,
@@ -60359,7 +60407,7 @@ fn __action1559<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1560<
+fn __action1561<
 >(
     __0: (TextSize, Vec<(ast::Arg, Option<ast::Expr>)>, TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -60378,7 +60426,7 @@ fn __action1560<
         __3,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1307(
+    __action1308(
         __temp0,
         __4,
         __5,
@@ -60386,7 +60434,7 @@ fn __action1560<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1561<
+fn __action1562<
 >(
     __0: (TextSize, Vec<(ast::Arg, Option<ast::Expr>)>, TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -60403,7 +60451,7 @@ fn __action1561<
         __0,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1326(
+    __action1327(
         __temp0,
         __1,
         __2,
@@ -60415,7 +60463,7 @@ fn __action1561<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1562<
+fn __action1563<
 >(
     __0: (TextSize, Vec<(ast::Arg, Option<ast::Expr>)>, TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -60436,7 +60484,7 @@ fn __action1562<
         __2,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1326(
+    __action1327(
         __temp0,
         __3,
         __4,
@@ -60448,7 +60496,7 @@ fn __action1562<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1563<
+fn __action1564<
 >(
     __0: (TextSize, Vec<(ast::Arg, Option<ast::Expr>)>, TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -60471,7 +60519,7 @@ fn __action1563<
         __3,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1326(
+    __action1327(
         __temp0,
         __4,
         __5,
@@ -60483,7 +60531,7 @@ fn __action1563<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1564<
+fn __action1565<
 >(
     __0: (TextSize, Vec<(ast::Arg, Option<ast::Expr>)>, TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -60499,7 +60547,7 @@ fn __action1564<
         __0,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1327(
+    __action1328(
         __temp0,
         __1,
         __2,
@@ -60510,7 +60558,7 @@ fn __action1564<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1565<
+fn __action1566<
 >(
     __0: (TextSize, Vec<(ast::Arg, Option<ast::Expr>)>, TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -60530,7 +60578,7 @@ fn __action1565<
         __2,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1327(
+    __action1328(
         __temp0,
         __3,
         __4,
@@ -60541,7 +60589,7 @@ fn __action1565<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1566<
+fn __action1567<
 >(
     __0: (TextSize, Vec<(ast::Arg, Option<ast::Expr>)>, TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -60563,7 +60611,7 @@ fn __action1566<
         __3,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1327(
+    __action1328(
         __temp0,
         __4,
         __5,
@@ -60574,7 +60622,7 @@ fn __action1566<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1567<
+fn __action1568<
 >(
     __0: (TextSize, Vec<(ast::Arg, Option<ast::Expr>)>, TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -60592,7 +60640,7 @@ fn __action1567<
         __0,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1328(
+    __action1329(
         __temp0,
         __1,
         __2,
@@ -60605,7 +60653,7 @@ fn __action1567<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1568<
+fn __action1569<
 >(
     __0: (TextSize, Vec<(ast::Arg, Option<ast::Expr>)>, TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -60627,7 +60675,7 @@ fn __action1568<
         __2,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1328(
+    __action1329(
         __temp0,
         __3,
         __4,
@@ -60640,7 +60688,7 @@ fn __action1568<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1569<
+fn __action1570<
 >(
     __0: (TextSize, Vec<(ast::Arg, Option<ast::Expr>)>, TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -60664,7 +60712,7 @@ fn __action1569<
         __3,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1328(
+    __action1329(
         __temp0,
         __4,
         __5,
@@ -60677,7 +60725,7 @@ fn __action1569<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1570<
+fn __action1571<
 >(
     __0: (TextSize, Vec<(ast::Arg, Option<ast::Expr>)>, TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -60694,7 +60742,7 @@ fn __action1570<
         __0,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1329(
+    __action1330(
         __temp0,
         __1,
         __2,
@@ -60706,7 +60754,7 @@ fn __action1570<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1571<
+fn __action1572<
 >(
     __0: (TextSize, Vec<(ast::Arg, Option<ast::Expr>)>, TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -60727,7 +60775,7 @@ fn __action1571<
         __2,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1329(
+    __action1330(
         __temp0,
         __3,
         __4,
@@ -60739,7 +60787,7 @@ fn __action1571<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1572<
+fn __action1573<
 >(
     __0: (TextSize, Vec<(ast::Arg, Option<ast::Expr>)>, TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -60762,7 +60810,7 @@ fn __action1572<
         __3,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1329(
+    __action1330(
         __temp0,
         __4,
         __5,
@@ -60774,7 +60822,7 @@ fn __action1572<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1573<
+fn __action1574<
 >(
     __0: (TextSize, Vec<(ast::Arg, Option<ast::Expr>)>, TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -60789,7 +60837,7 @@ fn __action1573<
         __0,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1330(
+    __action1331(
         __temp0,
         __1,
         __2,
@@ -60799,7 +60847,7 @@ fn __action1573<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1574<
+fn __action1575<
 >(
     __0: (TextSize, Vec<(ast::Arg, Option<ast::Expr>)>, TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -60818,7 +60866,7 @@ fn __action1574<
         __2,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1330(
+    __action1331(
         __temp0,
         __3,
         __4,
@@ -60828,7 +60876,7 @@ fn __action1574<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1575<
+fn __action1576<
 >(
     __0: (TextSize, Vec<(ast::Arg, Option<ast::Expr>)>, TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -60849,7 +60897,7 @@ fn __action1575<
         __3,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1330(
+    __action1331(
         __temp0,
         __4,
         __5,
@@ -60859,7 +60907,7 @@ fn __action1575<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1576<
+fn __action1577<
 >(
     __0: (TextSize, Vec<(ast::Arg, Option<ast::Expr>)>, TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -60873,7 +60921,7 @@ fn __action1576<
         __0,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1331(
+    __action1332(
         __temp0,
         __1,
         __2,
@@ -60882,7 +60930,7 @@ fn __action1576<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1577<
+fn __action1578<
 >(
     __0: (TextSize, Vec<(ast::Arg, Option<ast::Expr>)>, TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -60900,7 +60948,7 @@ fn __action1577<
         __2,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1331(
+    __action1332(
         __temp0,
         __3,
         __4,
@@ -60909,7 +60957,7 @@ fn __action1577<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1578<
+fn __action1579<
 >(
     __0: (TextSize, Vec<(ast::Arg, Option<ast::Expr>)>, TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -60929,7 +60977,7 @@ fn __action1578<
         __3,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1331(
+    __action1332(
         __temp0,
         __4,
         __5,
@@ -60938,7 +60986,7 @@ fn __action1578<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1579<
+fn __action1580<
 >(
     __0: (TextSize, Vec<(ast::Arg, Option<ast::Expr>)>, TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -60954,7 +61002,7 @@ fn __action1579<
         __0,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1332(
+    __action1333(
         __temp0,
         __1,
         __2,
@@ -60965,7 +61013,7 @@ fn __action1579<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1580<
+fn __action1581<
 >(
     __0: (TextSize, Vec<(ast::Arg, Option<ast::Expr>)>, TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -60985,7 +61033,7 @@ fn __action1580<
         __2,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1332(
+    __action1333(
         __temp0,
         __3,
         __4,
@@ -60996,7 +61044,7 @@ fn __action1580<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1581<
+fn __action1582<
 >(
     __0: (TextSize, Vec<(ast::Arg, Option<ast::Expr>)>, TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -61018,7 +61066,7 @@ fn __action1581<
         __3,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1332(
+    __action1333(
         __temp0,
         __4,
         __5,
@@ -61029,7 +61077,7 @@ fn __action1581<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1582<
+fn __action1583<
 >(
     __0: (TextSize, Vec<(ast::Arg, Option<ast::Expr>)>, TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -61044,7 +61092,7 @@ fn __action1582<
         __0,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1333(
+    __action1334(
         __temp0,
         __1,
         __2,
@@ -61054,7 +61102,7 @@ fn __action1582<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1583<
+fn __action1584<
 >(
     __0: (TextSize, Vec<(ast::Arg, Option<ast::Expr>)>, TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -61073,7 +61121,7 @@ fn __action1583<
         __2,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1333(
+    __action1334(
         __temp0,
         __3,
         __4,
@@ -61083,7 +61131,7 @@ fn __action1583<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1584<
+fn __action1585<
 >(
     __0: (TextSize, Vec<(ast::Arg, Option<ast::Expr>)>, TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -61104,7 +61152,7 @@ fn __action1584<
         __3,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1333(
+    __action1334(
         __temp0,
         __4,
         __5,
@@ -61114,7 +61162,7 @@ fn __action1584<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1585<
+fn __action1586<
 >(
     __0: (TextSize, Vec<(ast::Arg, Option<ast::Expr>)>, TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -61126,14 +61174,14 @@ fn __action1585<
         __0,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1334(
+    __action1335(
         __temp0,
         __1,
     )
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1586<
+fn __action1587<
 >(
     __0: (TextSize, Vec<(ast::Arg, Option<ast::Expr>)>, TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -61149,14 +61197,14 @@ fn __action1586<
         __2,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1334(
+    __action1335(
         __temp0,
         __3,
     )
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1587<
+fn __action1588<
 >(
     __0: (TextSize, Vec<(ast::Arg, Option<ast::Expr>)>, TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -61174,14 +61222,14 @@ fn __action1587<
         __3,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1334(
+    __action1335(
         __temp0,
         __4,
     )
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1588<
+fn __action1589<
 >(
     __0: (TextSize, Vec<(ast::Arg, Option<ast::Expr>)>, TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -61197,7 +61245,7 @@ fn __action1588<
         __0,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1335(
+    __action1336(
         __temp0,
         __1,
         __2,
@@ -61208,7 +61256,7 @@ fn __action1588<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1589<
+fn __action1590<
 >(
     __0: (TextSize, Vec<(ast::Arg, Option<ast::Expr>)>, TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -61228,7 +61276,7 @@ fn __action1589<
         __2,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1335(
+    __action1336(
         __temp0,
         __3,
         __4,
@@ -61239,7 +61287,7 @@ fn __action1589<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1590<
+fn __action1591<
 >(
     __0: (TextSize, Vec<(ast::Arg, Option<ast::Expr>)>, TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -61261,7 +61309,7 @@ fn __action1590<
         __3,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1335(
+    __action1336(
         __temp0,
         __4,
         __5,
@@ -61272,7 +61320,7 @@ fn __action1590<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1591<
+fn __action1592<
 >(
     __0: (TextSize, Vec<(ast::Arg, Option<ast::Expr>)>, TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -61287,7 +61335,7 @@ fn __action1591<
         __0,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1336(
+    __action1337(
         __temp0,
         __1,
         __2,
@@ -61297,7 +61345,7 @@ fn __action1591<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1592<
+fn __action1593<
 >(
     __0: (TextSize, Vec<(ast::Arg, Option<ast::Expr>)>, TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -61316,7 +61364,7 @@ fn __action1592<
         __2,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1336(
+    __action1337(
         __temp0,
         __3,
         __4,
@@ -61326,7 +61374,7 @@ fn __action1592<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1593<
+fn __action1594<
 >(
     __0: (TextSize, Vec<(ast::Arg, Option<ast::Expr>)>, TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -61347,7 +61395,7 @@ fn __action1593<
         __3,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1336(
+    __action1337(
         __temp0,
         __4,
         __5,
@@ -61357,7 +61405,7 @@ fn __action1593<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1594<
+fn __action1595<
 >(
     __0: (TextSize, Vec<(ast::Arg, Option<ast::Expr>)>, TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -61374,7 +61422,7 @@ fn __action1594<
         __0,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1337(
+    __action1338(
         __temp0,
         __1,
         __2,
@@ -61386,7 +61434,7 @@ fn __action1594<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1595<
+fn __action1596<
 >(
     __0: (TextSize, Vec<(ast::Arg, Option<ast::Expr>)>, TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -61407,7 +61455,7 @@ fn __action1595<
         __2,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1337(
+    __action1338(
         __temp0,
         __3,
         __4,
@@ -61419,7 +61467,7 @@ fn __action1595<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1596<
+fn __action1597<
 >(
     __0: (TextSize, Vec<(ast::Arg, Option<ast::Expr>)>, TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -61442,7 +61490,7 @@ fn __action1596<
         __3,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1337(
+    __action1338(
         __temp0,
         __4,
         __5,
@@ -61454,7 +61502,7 @@ fn __action1596<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1597<
+fn __action1598<
 >(
     __0: (TextSize, Vec<(ast::Arg, Option<ast::Expr>)>, TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -61470,7 +61518,7 @@ fn __action1597<
         __0,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1338(
+    __action1339(
         __temp0,
         __1,
         __2,
@@ -61481,7 +61529,7 @@ fn __action1597<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1598<
+fn __action1599<
 >(
     __0: (TextSize, Vec<(ast::Arg, Option<ast::Expr>)>, TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -61501,7 +61549,7 @@ fn __action1598<
         __2,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1338(
+    __action1339(
         __temp0,
         __3,
         __4,
@@ -61512,7 +61560,7 @@ fn __action1598<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1599<
+fn __action1600<
 >(
     __0: (TextSize, Vec<(ast::Arg, Option<ast::Expr>)>, TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -61534,7 +61582,7 @@ fn __action1599<
         __3,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1338(
+    __action1339(
         __temp0,
         __4,
         __5,
@@ -61545,7 +61593,7 @@ fn __action1599<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1600<
+fn __action1601<
 >(
     __0: (TextSize, Vec<(ast::Arg, Option<ast::Expr>)>, TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -61559,7 +61607,7 @@ fn __action1600<
         __0,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1339(
+    __action1340(
         __temp0,
         __1,
         __2,
@@ -61568,7 +61616,7 @@ fn __action1600<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1601<
+fn __action1602<
 >(
     __0: (TextSize, Vec<(ast::Arg, Option<ast::Expr>)>, TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -61586,7 +61634,7 @@ fn __action1601<
         __2,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1339(
+    __action1340(
         __temp0,
         __3,
         __4,
@@ -61595,7 +61643,7 @@ fn __action1601<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1602<
+fn __action1603<
 >(
     __0: (TextSize, Vec<(ast::Arg, Option<ast::Expr>)>, TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -61615,7 +61663,7 @@ fn __action1602<
         __3,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1339(
+    __action1340(
         __temp0,
         __4,
         __5,
@@ -61624,7 +61672,7 @@ fn __action1602<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1603<
+fn __action1604<
 >(
     __0: (TextSize, Vec<(ast::Arg, Option<ast::Expr>)>, TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -61637,7 +61685,7 @@ fn __action1603<
         __0,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1340(
+    __action1341(
         __temp0,
         __1,
         __2,
@@ -61645,7 +61693,7 @@ fn __action1603<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1604<
+fn __action1605<
 >(
     __0: (TextSize, Vec<(ast::Arg, Option<ast::Expr>)>, TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -61662,7 +61710,7 @@ fn __action1604<
         __2,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1340(
+    __action1341(
         __temp0,
         __3,
         __4,
@@ -61670,7 +61718,7 @@ fn __action1604<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1605<
+fn __action1606<
 >(
     __0: (TextSize, Vec<(ast::Arg, Option<ast::Expr>)>, TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -61689,7 +61737,7 @@ fn __action1605<
         __3,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1340(
+    __action1341(
         __temp0,
         __4,
         __5,
@@ -61697,7 +61745,7 @@ fn __action1605<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1606<
+fn __action1607<
 >(
     __0: (TextSize, Vec<(ast::Arg, Option<ast::Expr>)>, TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -61712,7 +61760,7 @@ fn __action1606<
         __0,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1341(
+    __action1342(
         __temp0,
         __1,
         __2,
@@ -61722,7 +61770,7 @@ fn __action1606<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1607<
+fn __action1608<
 >(
     __0: (TextSize, Vec<(ast::Arg, Option<ast::Expr>)>, TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -61741,7 +61789,7 @@ fn __action1607<
         __2,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1341(
+    __action1342(
         __temp0,
         __3,
         __4,
@@ -61751,7 +61799,7 @@ fn __action1607<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1608<
+fn __action1609<
 >(
     __0: (TextSize, Vec<(ast::Arg, Option<ast::Expr>)>, TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -61772,7 +61820,7 @@ fn __action1608<
         __3,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1341(
+    __action1342(
         __temp0,
         __4,
         __5,
@@ -61782,7 +61830,7 @@ fn __action1608<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1609<
+fn __action1610<
 >(
     __0: (TextSize, Vec<(ast::Arg, Option<ast::Expr>)>, TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -61796,7 +61844,7 @@ fn __action1609<
         __0,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1342(
+    __action1343(
         __temp0,
         __1,
         __2,
@@ -61805,7 +61853,7 @@ fn __action1609<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1610<
+fn __action1611<
 >(
     __0: (TextSize, Vec<(ast::Arg, Option<ast::Expr>)>, TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -61823,7 +61871,7 @@ fn __action1610<
         __2,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1342(
+    __action1343(
         __temp0,
         __3,
         __4,
@@ -61832,7 +61880,7 @@ fn __action1610<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1611<
+fn __action1612<
 >(
     __0: (TextSize, Vec<(ast::Arg, Option<ast::Expr>)>, TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -61852,7 +61900,7 @@ fn __action1611<
         __3,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1342(
+    __action1343(
         __temp0,
         __4,
         __5,
@@ -61861,7 +61909,7 @@ fn __action1611<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1612<
+fn __action1613<
 >(
     __0: (TextSize, Vec<(ast::Arg, Option<ast::Expr>)>, TextSize),
 ) -> Result<ast::Arguments,__lalrpop_util::ParseError<TextSize,token::Tok,LexicalError>>
@@ -61872,13 +61920,13 @@ fn __action1612<
         __0,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1343(
+    __action1344(
         __temp0,
     )
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1613<
+fn __action1614<
 >(
     __0: (TextSize, Vec<(ast::Arg, Option<ast::Expr>)>, TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -61893,13 +61941,13 @@ fn __action1613<
         __2,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1343(
+    __action1344(
         __temp0,
     )
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1614<
+fn __action1615<
 >(
     __0: (TextSize, Vec<(ast::Arg, Option<ast::Expr>)>, TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -61916,13 +61964,13 @@ fn __action1614<
         __3,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1343(
+    __action1344(
         __temp0,
     )
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1615<
+fn __action1616<
 >(
     __0: (TextSize, Vec<(ast::Arg, Option<ast::Expr>)>, TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -61936,7 +61984,7 @@ fn __action1615<
         __0,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1344(
+    __action1345(
         __temp0,
         __1,
         __2,
@@ -61945,7 +61993,7 @@ fn __action1615<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1616<
+fn __action1617<
 >(
     __0: (TextSize, Vec<(ast::Arg, Option<ast::Expr>)>, TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -61963,7 +62011,7 @@ fn __action1616<
         __2,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1344(
+    __action1345(
         __temp0,
         __3,
         __4,
@@ -61972,7 +62020,7 @@ fn __action1616<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1617<
+fn __action1618<
 >(
     __0: (TextSize, Vec<(ast::Arg, Option<ast::Expr>)>, TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -61992,7 +62040,7 @@ fn __action1617<
         __3,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1344(
+    __action1345(
         __temp0,
         __4,
         __5,
@@ -62001,7 +62049,7 @@ fn __action1617<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1618<
+fn __action1619<
 >(
     __0: (TextSize, Vec<(ast::Arg, Option<ast::Expr>)>, TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -62014,7 +62062,7 @@ fn __action1618<
         __0,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1345(
+    __action1346(
         __temp0,
         __1,
         __2,
@@ -62022,7 +62070,7 @@ fn __action1618<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1619<
+fn __action1620<
 >(
     __0: (TextSize, Vec<(ast::Arg, Option<ast::Expr>)>, TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -62039,7 +62087,7 @@ fn __action1619<
         __2,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1345(
+    __action1346(
         __temp0,
         __3,
         __4,
@@ -62047,7 +62095,7 @@ fn __action1619<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1620<
+fn __action1621<
 >(
     __0: (TextSize, Vec<(ast::Arg, Option<ast::Expr>)>, TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -62066,7 +62114,7 @@ fn __action1620<
         __3,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1345(
+    __action1346(
         __temp0,
         __4,
         __5,
@@ -62074,7 +62122,7 @@ fn __action1620<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1621<
+fn __action1622<
 >(
     __0: (TextSize, token::Tok, TextSize),
     __1: (TextSize, ast::Arguments, TextSize),
@@ -62088,7 +62136,7 @@ fn __action1621<
         __1,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1261(
+    __action1262(
         __0,
         __temp0,
         __2,
@@ -62097,7 +62145,7 @@ fn __action1621<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1622<
+fn __action1623<
 >(
     __0: (TextSize, token::Tok, TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -62111,7 +62159,7 @@ fn __action1622<
         &__end0,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1261(
+    __action1262(
         __0,
         __temp0,
         __1,
@@ -62120,7 +62168,7 @@ fn __action1622<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1623<
+fn __action1624<
 >(
     __0: (TextSize, core::option::Option<ast::Expr>, TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -62134,7 +62182,7 @@ fn __action1623<
         __3,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1388(
+    __action1389(
         __0,
         __1,
         __2,
@@ -62143,7 +62191,7 @@ fn __action1623<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1624<
+fn __action1625<
 >(
     __0: (TextSize, core::option::Option<ast::Expr>, TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -62157,7 +62205,7 @@ fn __action1624<
         &__end0,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1388(
+    __action1389(
         __0,
         __1,
         __2,
@@ -62166,7 +62214,7 @@ fn __action1624<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1625<
+fn __action1626<
 >(
     __0: (TextSize, token::Tok, TextSize),
     __1: (TextSize, ast::Expr, TextSize),
@@ -62189,7 +62237,7 @@ fn __action1625<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1626<
+fn __action1627<
 >(
     __0: (TextSize, token::Tok, TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -62212,7 +62260,7 @@ fn __action1626<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1627<
+fn __action1628<
 >(
     __0: (TextSize, token::Tok, TextSize),
     __1: (TextSize, ast::Expr, TextSize),
@@ -62231,7 +62279,7 @@ fn __action1627<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1628<
+fn __action1629<
 >(
     __0: (TextSize, token::Tok, TextSize),
 ) -> Option<ast::Expr>
@@ -62250,7 +62298,7 @@ fn __action1628<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1629<
+fn __action1630<
 >(
     __0: (TextSize, ast::Expr, TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -62270,7 +62318,7 @@ fn __action1629<
         __2,
     );
     let __temp1 = (__start1, __temp1, __end1);
-    __action1623(
+    __action1624(
         __temp0,
         __1,
         __temp1,
@@ -62279,7 +62327,7 @@ fn __action1629<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1630<
+fn __action1631<
 >(
     __0: (TextSize, ast::Expr, TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -62299,7 +62347,7 @@ fn __action1630<
         &__end1,
     );
     let __temp1 = (__start1, __temp1, __end1);
-    __action1623(
+    __action1624(
         __temp0,
         __1,
         __temp1,
@@ -62308,7 +62356,7 @@ fn __action1630<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1631<
+fn __action1632<
 >(
     __0: (TextSize, token::Tok, TextSize),
     __1: (TextSize, ast::Expr, TextSize),
@@ -62328,7 +62376,7 @@ fn __action1631<
         __1,
     );
     let __temp1 = (__start1, __temp1, __end1);
-    __action1623(
+    __action1624(
         __temp0,
         __0,
         __temp1,
@@ -62337,7 +62385,7 @@ fn __action1631<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1632<
+fn __action1633<
 >(
     __0: (TextSize, token::Tok, TextSize),
     __1: (TextSize, Option<ast::Expr>, TextSize),
@@ -62357,7 +62405,7 @@ fn __action1632<
         &__end1,
     );
     let __temp1 = (__start1, __temp1, __end1);
-    __action1623(
+    __action1624(
         __temp0,
         __0,
         __temp1,
@@ -62366,7 +62414,7 @@ fn __action1632<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1633<
+fn __action1634<
 >(
     __0: (TextSize, ast::Expr, TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -62385,7 +62433,7 @@ fn __action1633<
         __2,
     );
     let __temp1 = (__start1, __temp1, __end1);
-    __action1624(
+    __action1625(
         __temp0,
         __1,
         __temp1,
@@ -62393,7 +62441,7 @@ fn __action1633<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1634<
+fn __action1635<
 >(
     __0: (TextSize, ast::Expr, TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -62412,7 +62460,7 @@ fn __action1634<
         &__end1,
     );
     let __temp1 = (__start1, __temp1, __end1);
-    __action1624(
+    __action1625(
         __temp0,
         __1,
         __temp1,
@@ -62420,7 +62468,7 @@ fn __action1634<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1635<
+fn __action1636<
 >(
     __0: (TextSize, token::Tok, TextSize),
     __1: (TextSize, ast::Expr, TextSize),
@@ -62439,7 +62487,7 @@ fn __action1635<
         __1,
     );
     let __temp1 = (__start1, __temp1, __end1);
-    __action1624(
+    __action1625(
         __temp0,
         __0,
         __temp1,
@@ -62447,7 +62495,7 @@ fn __action1635<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1636<
+fn __action1637<
 >(
     __0: (TextSize, token::Tok, TextSize),
 ) -> ast::Expr
@@ -62466,7 +62514,7 @@ fn __action1636<
         &__end1,
     );
     let __temp1 = (__start1, __temp1, __end1);
-    __action1624(
+    __action1625(
         __temp0,
         __0,
         __temp1,
@@ -62474,7 +62522,7 @@ fn __action1636<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1637<
+fn __action1638<
 >(
     __0: (TextSize, token::Tok, TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -62509,7 +62557,7 @@ fn __action1637<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1638<
+fn __action1639<
 >(
     __0: (TextSize, token::Tok, TextSize),
     __1: (TextSize, token::Tok, TextSize),
@@ -62538,7 +62586,7 @@ fn __action1638<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1639<
+fn __action1640<
 >(
     __0: (TextSize, token::Tok, TextSize),
     __1: (TextSize, ast::Expr, TextSize),
@@ -62571,7 +62619,7 @@ fn __action1639<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1640<
+fn __action1641<
 >(
     __0: (TextSize, token::Tok, TextSize),
     __1: (TextSize, ast::Expr, TextSize),
@@ -62598,7 +62646,7 @@ fn __action1640<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1641<
+fn __action1642<
 >(
     __0: (TextSize, ast::Expr, TextSize),
 ) -> core::option::Option<ast::Expr>
@@ -62615,7 +62663,7 @@ fn __action1641<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1642<
+fn __action1643<
 >(
     __0: (TextSize, ast::Expr, TextSize),
 ) -> ast::Expr
@@ -62632,7 +62680,7 @@ fn __action1642<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1643<
+fn __action1644<
 >(
     __0: (TextSize, ast::Expr, TextSize),
 ) -> ast::Expr
@@ -62649,7 +62697,7 @@ fn __action1643<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1644<
+fn __action1645<
 >(
     __0: (TextSize, token::Tok, TextSize),
     __1: (TextSize, ast::Expr, TextSize),
@@ -62661,14 +62709,14 @@ fn __action1644<
         __1,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1399(
+    __action1400(
         __0,
         __temp0,
     )
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1645<
+fn __action1646<
 >(
     __0: (TextSize, token::Tok, TextSize),
     __1: (TextSize, ast::Expr, TextSize),
@@ -62681,7 +62729,7 @@ fn __action1645<
         __1,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1400(
+    __action1401(
         __0,
         __temp0,
         __2,
@@ -62689,7 +62737,7 @@ fn __action1645<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1646<
+fn __action1647<
 >(
     __0: (TextSize, token::Tok, TextSize),
     __1: (TextSize, ast::Expr, TextSize),
@@ -62697,30 +62745,11 @@ fn __action1646<
 {
     let __start0 = __1.0;
     let __end0 = __1.2;
-    let __temp0 = __action1641(
+    let __temp0 = __action1642(
         __1,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1240(
-        __0,
-        __temp0,
-    )
-}
-
-#[allow(clippy::too_many_arguments)]
-fn __action1647<
->(
-    __0: (TextSize, token::Tok, TextSize),
-) -> ast::Stmt
-{
-    let __start0 = __0.2;
-    let __end0 = __0.2;
-    let __temp0 = __action354(
-        &__start0,
-        &__end0,
-    );
-    let __temp0 = (__start0, __temp0, __end0);
-    __action1240(
+    __action1241(
         __0,
         __temp0,
     )
@@ -62730,16 +62759,16 @@ fn __action1647<
 fn __action1648<
 >(
     __0: (TextSize, token::Tok, TextSize),
-    __1: (TextSize, ast::Expr, TextSize),
-) -> ast::Expr
+) -> ast::Stmt
 {
-    let __start0 = __1.0;
-    let __end0 = __1.2;
-    let __temp0 = __action1641(
-        __1,
+    let __start0 = __0.2;
+    let __end0 = __0.2;
+    let __temp0 = __action354(
+        &__start0,
+        &__end0,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1421(
+    __action1241(
         __0,
         __temp0,
     )
@@ -62747,6 +62776,25 @@ fn __action1648<
 
 #[allow(clippy::too_many_arguments)]
 fn __action1649<
+>(
+    __0: (TextSize, token::Tok, TextSize),
+    __1: (TextSize, ast::Expr, TextSize),
+) -> ast::Expr
+{
+    let __start0 = __1.0;
+    let __end0 = __1.2;
+    let __temp0 = __action1642(
+        __1,
+    );
+    let __temp0 = (__start0, __temp0, __end0);
+    __action1422(
+        __0,
+        __temp0,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn __action1650<
 >(
     __0: (TextSize, token::Tok, TextSize),
 ) -> ast::Expr
@@ -62758,25 +62806,8 @@ fn __action1649<
         &__end0,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1421(
+    __action1422(
         __0,
-        __temp0,
-    )
-}
-
-#[allow(clippy::too_many_arguments)]
-fn __action1650<
->(
-    __0: (TextSize, ast::Expr, TextSize),
-) -> ast::Stmt
-{
-    let __start0 = __0.0;
-    let __end0 = __0.2;
-    let __temp0 = __action1643(
-        __0,
-    );
-    let __temp0 = (__start0, __temp0, __end0);
-    __action1445(
         __temp0,
     )
 }
@@ -62785,23 +62816,40 @@ fn __action1650<
 fn __action1651<
 >(
     __0: (TextSize, ast::Expr, TextSize),
+) -> ast::Stmt
+{
+    let __start0 = __0.0;
+    let __end0 = __0.2;
+    let __temp0 = __action1644(
+        __0,
+    );
+    let __temp0 = (__start0, __temp0, __end0);
+    __action1446(
+        __temp0,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn __action1652<
+>(
+    __0: (TextSize, ast::Expr, TextSize),
     __1: (TextSize, alloc::vec::Vec<ast::Expr>, TextSize),
 ) -> ast::Stmt
 {
     let __start0 = __0.0;
     let __end0 = __0.2;
-    let __temp0 = __action1643(
+    let __temp0 = __action1644(
         __0,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1446(
+    __action1447(
         __temp0,
         __1,
     )
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1652<
+fn __action1653<
 >(
     __0: (TextSize, ast::Expr, TextSize),
     __1: (TextSize, ast::Operator, TextSize),
@@ -62810,11 +62858,11 @@ fn __action1652<
 {
     let __start0 = __0.0;
     let __end0 = __0.2;
-    let __temp0 = __action1643(
+    let __temp0 = __action1644(
         __0,
     );
     let __temp0 = (__start0, __temp0, __end0);
-    __action1234(
+    __action1235(
         __temp0,
         __1,
         __2,
@@ -62822,7 +62870,7 @@ fn __action1652<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1653<
+fn __action1654<
 >(
     __0: (TextSize, token::Tok, TextSize),
     __1: (TextSize, ast::Arg, TextSize),
@@ -62841,7 +62889,7 @@ fn __action1653<
 }
 
 #[allow(clippy::too_many_arguments)]
-fn __action1654<
+fn __action1655<
 >(
     __0: (TextSize, token::Tok, TextSize),
 ) -> Option<Box<ast::Arg>>

--- a/parser/src/snapshots/rustpython_parser__parser__tests__decorator_ranges.snap
+++ b/parser/src/snapshots/rustpython_parser__parser__tests__decorator_ranges.snap
@@ -10,7 +10,7 @@ expression: parse_ast
                 "test",
             ),
             args: Arguments {
-                range: (),
+                range: 22..24,
                 posonlyargs: [],
                 args: [],
                 vararg: None,
@@ -27,15 +27,18 @@ expression: parse_ast
                 ),
             ],
             decorator_list: [
-                Name(
-                    ExprName {
-                        range: 1..13,
-                        id: Identifier(
-                            "my_decorator",
-                        ),
-                        ctx: Load,
-                    },
-                ),
+                Decorator {
+                    range: 0..13,
+                    expression: Name(
+                        ExprName {
+                            range: 1..13,
+                            id: Identifier(
+                                "my_decorator",
+                            ),
+                            ctx: Load,
+                        },
+                    ),
+                },
             ],
             returns: None,
             type_comment: None,
@@ -57,15 +60,18 @@ expression: parse_ast
                 ),
             ],
             decorator_list: [
-                Name(
-                    ExprName {
-                        range: 41..56,
-                        id: Identifier(
-                            "class_decorator",
-                        ),
-                        ctx: Load,
-                    },
-                ),
+                Decorator {
+                    range: 40..56,
+                    expression: Name(
+                        ExprName {
+                            range: 41..56,
+                            id: Identifier(
+                                "class_decorator",
+                            ),
+                            ctx: Load,
+                        },
+                    ),
+                },
             ],
         },
     ),


### PR DESCRIPTION
This PR introduces a new `Decorator` node. The node wraps an expression and its range includes the `@`. 

Having a dedicated node for `Decorator`s simplifies the implementation of the Formatter when handling leading comments:

```python
@deco1
# leading 2
@deco2(with_args=True)
# leading 3
@deco3

# leading 4 that already has an empty line
def decorated_with_split_leading_comments():
    pass
```

The leading comment should be attached to the whole decorator and not just the expression coming after the `@`. It's also necessary that we distinguish between comments attached to the decorator vs comments attached to the decorator's expression:

```python
@(
    # leading 3
    deco3
)
```

This is straightforward when the decorator and the expression are different nodes. 


This change has the added benefit that the Linter now gets the full range of the decorator. For example, we have fixes that replace remove the whole decorator but they incorrectly assume that its safe to subtract 1 from the start (offset of the `@`). However, this doesn't account for:

```python
@         deco2(with_args=True)
def decorated1():
    pass
    
```

which is valid python 