### PR TITLE
Fix range of keyword identifier

### DIFF
--- a/parser/src/function.rs
+++ b/parser/src/function.rs
@@ -103,7 +103,7 @@ pub(crate) fn parse_args(func_args: Vec<FunctionArgument>) -> Result<ArgumentLis
                 }
 
                 keywords.push(ast::Keyword {
-                    arg: name.map(|name| ast::Identifier::new(name, TextRange::new(start, end))),
+                    arg: name,
                     value,
                     range: TextRange::new(start, end),
                 });

--- a/parser/src/snapshots/rustpython_parser__parser__tests__parse_kwargs.snap
+++ b/parser/src/snapshots/rustpython_parser__parser__tests__parse_kwargs.snap
@@ -33,7 +33,7 @@ expression: parse_ast
                             arg: Some(
                                 Identifier {
                                     id: "keyword",
-                                    range: 22..31,
+                                    range: 22..29,
                                 },
                             ),
                             value: Constant(


### PR DESCRIPTION
This PR fixes the range of keyword argument identifiers. The range incorrectly included the default value (if any).

```python
a=3
```

The range of the identifier `a` spanned the whole text instead of just the span of `a` 
