### PR TITLE
impl<T> Ranged for &T where T: Ranged

### DIFF
--- a/ast/src/ranged.rs
+++ b/ast/src/ranged.rs
@@ -14,4 +14,10 @@ pub trait Ranged {
     }
 }
 
+impl<T> Ranged for &T where T: Ranged {
+    fn range(&self) -> TextRange {
+        self.range()
+    }
+}
+
 include!("gen/ranged.rs");

--- a/ast/src/ranged.rs
+++ b/ast/src/ranged.rs
@@ -19,7 +19,7 @@ where
     T: Ranged,
 {
     fn range(&self) -> TextRange {
-        self.range()
+        T::range(self)
     }
 }
 

--- a/ast/src/ranged.rs
+++ b/ast/src/ranged.rs
@@ -14,7 +14,10 @@ pub trait Ranged {
     }
 }
 
-impl<T> Ranged for &T where T: Ranged {
+impl<T> Ranged for &T
+where
+    T: Ranged,
+{
     fn range(&self) -> TextRange {
         self.range()
     }


### PR DESCRIPTION
In the example below, `arg` is `&Expr`, so `&Ranged`, but `entries()` want a `T: Ranged`. This adds the missing bridge impl.

```rust
        let all_args = format_with(|f| {
            f.join_comma_separated()
                .entries(
                    // We have the parentheses from the call so the arguments never need any
                    args.iter()
                        .map(|arg| (arg, arg.format().with_options(Parenthesize::Never))),
                )
                .nodes(keywords.iter())
                .finish()
        });
```