### PR TITLE
impl Ranged for TextRange

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ __pycache__
 .*sw*
 .vscode
 .idea/
+.venv/
 
 flame-graph.html
 flame.txt

--- a/ast/src/ranged.rs
+++ b/ast/src/ranged.rs
@@ -14,6 +14,12 @@ pub trait Ranged {
     }
 }
 
+impl Ranged for TextRange {
+    fn range(&self) -> TextRange {
+        *self
+    }
+}
+
 impl<T> Ranged for &T
 where
     T: Ranged,


### PR DESCRIPTION
This adds the missing implementation of `Ranged` for `TextRange` itself

```rust
impl Ranged for TextRange {
    fn range(&self) -> TextRange {
        *self
    }
}
```

This allows e.g. using `has_comments` with arbitrary ranges instead of just a node.

It also adds .venv to the .gitignore

