### PR TITLE
Lex Jupyter line magic with `Mode::Jupyter`

### DIFF
--- a/core/src/mode.rs
+++ b/core/src/mode.rs
@@ -9,7 +9,8 @@ pub enum Mode {
     Interactive,
     /// The code consists of a single expression.
     Expression,
-    /// The code is a Jupyter notebook.
+    /// The code consists of a sequence of statements which are part of a
+    /// Jupyter notebook and thus could include magics.
     Jupyter,
 }
 

--- a/core/src/mode.rs
+++ b/core/src/mode.rs
@@ -1,7 +1,7 @@
 //! Control in the different modes by which a source file can be parsed.
 
 /// The mode argument specifies in what way code must be parsed.
-#[derive(Clone, Copy, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
 pub enum Mode {
     /// The code consists of a sequence of statements.
     Module,

--- a/core/src/mode.rs
+++ b/core/src/mode.rs
@@ -9,6 +9,8 @@ pub enum Mode {
     Interactive,
     /// The code consists of a single expression.
     Expression,
+    /// The code is a Jupyter notebook.
+    Jupyter,
 }
 
 impl std::str::FromStr for Mode {
@@ -17,6 +19,7 @@ impl std::str::FromStr for Mode {
         match s {
             "exec" | "single" => Ok(Mode::Module),
             "eval" => Ok(Mode::Expression),
+            "jupyter" => Ok(Mode::Jupyter),
             _ => Err(ModeParseError),
         }
     }
@@ -28,6 +31,6 @@ pub struct ModeParseError;
 
 impl std::fmt::Display for ModeParseError {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        write!(f, r#"mode must be "exec", "eval", or "single""#)
+        write!(f, r#"mode must be "exec", "eval", "jupyter", or "single""#)
     }
 }

--- a/core/src/mode.rs
+++ b/core/src/mode.rs
@@ -10,7 +10,32 @@ pub enum Mode {
     /// The code consists of a single expression.
     Expression,
     /// The code consists of a sequence of statements which are part of a
-    /// Jupyter notebook and thus could include magics.
+    /// Jupyter Notebook and thus could include escape commands scoped to
+    /// a single line.
+    ///
+    /// ## Limitations:
+    ///
+    /// These escaped commands are only supported when they are the only
+    /// statement on a line. If they're part of a larger statement such as
+    /// on the right-hand side of an assignment, the lexer will not recognize
+    /// them as escape commands.
+    ///
+    /// For [Dynamic object information], the escape characters (`?`, `??`)
+    /// must be used before an object. For example, `?foo` will be recognized,
+    /// but `foo?` will not.
+    ///
+    /// ## Supported escape commands:
+    /// - [Magic command system] which is limited to [line magics] and can start
+    ///   with `?` or `??`.
+    /// - [Dynamic object information] which can start with `?` or `??`.
+    /// - [System shell access] which can start with `!` or `!!`.
+    /// - [Automatic parentheses and quotes] which can start with `/`, `;`, or `,`.
+    ///
+    /// [Magic command system]: https://ipython.readthedocs.io/en/stable/interactive/reference.html#magic-command-system
+    /// [line magics]: https://ipython.readthedocs.io/en/stable/interactive/magics.html#line-magics
+    /// [Dynamic object information]: https://ipython.readthedocs.io/en/stable/interactive/reference.html#dynamic-object-information
+    /// [System shell access]: https://ipython.readthedocs.io/en/stable/interactive/reference.html#system-shell-access
+    /// [Automatic parentheses and quotes]: https://ipython.readthedocs.io/en/stable/interactive/reference.html#automatic-parentheses-and-quotes
     Jupyter,
 }
 

--- a/parser/src/lexer.rs
+++ b/parser/src/lexer.rs
@@ -516,20 +516,9 @@ where
                     //      && ls -a | sed 's/^/\\    /'
                     //                          ^^
                     //                          Don't skip these backslashes
-                    match self.window[1..3] {
-                        [Some('\n'), _] => {
-                            self.next_char(); // '\'
-                            self.next_char(); // '\n'
-                        }
-                        [Some('\r'), Some(ch)] => {
-                            self.next_char(); // '\'
-                            if matches!(ch, '\n') {
-                                self.next_char(); // '\r\n'
-                            } else {
-                                self.next_char(); // '\r'
-                            }
-                        }
-                        _ => (),
+                    if matches!(self.window[1], Some('\n' | '\r')) {
+                        self.next_char();
+                        self.next_char();
                     }
                 }
                 Some('\n' | '\r') | None => {

--- a/parser/src/lexer.rs
+++ b/parser/src/lexer.rs
@@ -535,13 +535,17 @@ where
     }
 
     fn lex_and_emit_magic_command(&mut self) {
-        if let [Some(c1), Some(c2)] = self.window[..2] {
-            if let Ok(kind) =
+        let kind = match self.window[..2] {
+            [Some(c1), Some(c2)] => {
                 MagicKind::try_from([c1, c2]).map_or_else(|_| MagicKind::try_from(c1), Ok)
-            {
-                let magic_command = self.lex_magic_command(kind);
-                self.emit(magic_command);
             }
+            // When the escape character is the last character of the file.
+            [Some(c), None] => MagicKind::try_from(c),
+            _ => return,
+        };
+        if let Ok(kind) = kind {
+            let magic_command = self.lex_magic_command(kind);
+            self.emit(magic_command);
         }
     }
 

--- a/parser/src/lexer.rs
+++ b/parser/src/lexer.rs
@@ -1461,28 +1461,31 @@ mod tests {
         }
     }
 
-    macro_rules! test_jupyter_magic_line_continuation_eol {
-        ($($name:ident: $eol:expr,)*) => {
-            $(
-            #[test]
-            fn $name() {
-                let source = format!("%matplotlib \\{}  --inline", $eol);
-                let tokens = lex_jupyter_source(&source);
-                assert_eq!(
-                    tokens,
-                    vec![
-                        Tok::MagicCommand { value: "matplotlib   --inline".to_string(), kind: MagicKind::Magic },
-                    ]
-                )
-            }
-            )*
-        };
+    fn assert_jupyter_magic_line_continuation_with_eol(eol: &str) {
+        let source = format!("%matplotlib \\{}  --inline", eol);
+        let tokens = lex_jupyter_source(&source);
+        assert_eq!(
+            tokens,
+            vec![Tok::MagicCommand {
+                value: "matplotlib   --inline".to_string(),
+                kind: MagicKind::Magic
+            },]
+        )
     }
 
-    test_jupyter_magic_line_continuation_eol! {
-        test_jupyter_magic_line_continuation_windows_eol: WINDOWS_EOL,
-        test_jupyter_magic_line_continuation_mac_eol: MAC_EOL,
-        test_jupyter_magic_line_continuation_unix_eol: UNIX_EOL,
+    #[test]
+    fn test_jupyter_magic_line_continuation_unix_eol() {
+        assert_jupyter_magic_line_continuation_with_eol(UNIX_EOL);
+    }
+
+    #[test]
+    fn test_jupyter_magic_line_continuation_mac_eol() {
+        assert_jupyter_magic_line_continuation_with_eol(MAC_EOL);
+    }
+
+    #[test]
+    fn test_jupyter_magic_line_continuation_windows_eol() {
+        assert_jupyter_magic_line_continuation_with_eol(WINDOWS_EOL);
     }
 
     #[test]

--- a/parser/src/lexer.rs
+++ b/parser/src/lexer.rs
@@ -702,8 +702,6 @@ where
                 // https://github.com/ipython/ipython/blob/635815e8f1ded5b764d66cacc80bbe25e9e2587f/IPython/core/inputtransformer2.py#L345
                 Some('%' | '!' | '?' | '/' | ';' | ',') if self.mode == Mode::Jupyter => {
                     self.lex_and_emit_magic_command();
-                    spaces = 0;
-                    tabs = 0;
                 }
                 Some('\x0C') => {
                     // Form feed character!

--- a/parser/src/lexer.rs
+++ b/parser/src/lexer.rs
@@ -1488,6 +1488,141 @@ mod tests {
     }
 
     #[test]
+    fn test_empty_jupyter_magic() {
+        let source = "%\n%%\n!\n!!\n?\n??\n/\n,\n;";
+        let tokens = lex_jupyter_source(source);
+        assert_eq!(
+            tokens,
+            vec![
+                Tok::MagicCommand {
+                    value: "".to_string(),
+                    kind: MagicKind::Magic,
+                },
+                Tok::NonLogicalNewline,
+                Tok::MagicCommand {
+                    value: "".to_string(),
+                    kind: MagicKind::Magic2,
+                },
+                Tok::NonLogicalNewline,
+                Tok::MagicCommand {
+                    value: "".to_string(),
+                    kind: MagicKind::Shell,
+                },
+                Tok::NonLogicalNewline,
+                Tok::MagicCommand {
+                    value: "".to_string(),
+                    kind: MagicKind::ShCap,
+                },
+                Tok::NonLogicalNewline,
+                Tok::MagicCommand {
+                    value: "".to_string(),
+                    kind: MagicKind::Help,
+                },
+                Tok::NonLogicalNewline,
+                Tok::MagicCommand {
+                    value: "".to_string(),
+                    kind: MagicKind::Help2,
+                },
+                Tok::NonLogicalNewline,
+                Tok::MagicCommand {
+                    value: "".to_string(),
+                    kind: MagicKind::Paren,
+                },
+                Tok::NonLogicalNewline,
+                Tok::MagicCommand {
+                    value: "".to_string(),
+                    kind: MagicKind::Quote,
+                },
+                Tok::NonLogicalNewline,
+                Tok::MagicCommand {
+                    value: "".to_string(),
+                    kind: MagicKind::Quote2,
+                },
+            ]
+        )
+    }
+
+    #[test]
+    fn test_jupyter_magic() {
+        let source = r"
+?foo
+??foo
+%timeit a = b
+%timeit a % 3
+%matplotlib \
+    --inline
+!pwd \
+  && ls -a | sed 's/^/\\    /'
+!!cd /Users/foo/Library/Application\ Support/
+/foo 1 2
+,foo 1 2
+;foo 1 2
+    !ls
+"
+        .trim();
+        let tokens = lex_jupyter_source(source);
+        assert_eq!(
+            tokens,
+            vec![
+                Tok::MagicCommand {
+                    value: "foo".to_string(),
+                    kind: MagicKind::Help,
+                },
+                Tok::NonLogicalNewline,
+                Tok::MagicCommand {
+                    value: "foo".to_string(),
+                    kind: MagicKind::Help2,
+                },
+                Tok::NonLogicalNewline,
+                Tok::MagicCommand {
+                    value: "timeit a = b".to_string(),
+                    kind: MagicKind::Magic,
+                },
+                Tok::NonLogicalNewline,
+                Tok::MagicCommand {
+                    value: "timeit a % 3".to_string(),
+                    kind: MagicKind::Magic,
+                },
+                Tok::NonLogicalNewline,
+                Tok::MagicCommand {
+                    value: "matplotlib     --inline".to_string(),
+                    kind: MagicKind::Magic,
+                },
+                Tok::NonLogicalNewline,
+                Tok::MagicCommand {
+                    value: "pwd   && ls -a | sed 's/^/\\\\    /'".to_string(),
+                    kind: MagicKind::Shell,
+                },
+                Tok::NonLogicalNewline,
+                Tok::MagicCommand {
+                    value: "cd /Users/foo/Library/Application\\ Support/".to_string(),
+                    kind: MagicKind::ShCap,
+                },
+                Tok::NonLogicalNewline,
+                Tok::MagicCommand {
+                    value: "foo 1 2".to_string(),
+                    kind: MagicKind::Paren,
+                },
+                Tok::NonLogicalNewline,
+                Tok::MagicCommand {
+                    value: "foo 1 2".to_string(),
+                    kind: MagicKind::Quote,
+                },
+                Tok::NonLogicalNewline,
+                Tok::MagicCommand {
+                    value: "foo 1 2".to_string(),
+                    kind: MagicKind::Quote2,
+                },
+                Tok::NonLogicalNewline,
+                Tok::MagicCommand {
+                    value: "ls".to_string(),
+                    kind: MagicKind::Shell,
+                },
+            ]
+        )
+    }
+
+    #[test]
     fn test_numbers() {
         let source = "0x2f 0o12 0b1101 0 123 123_45_67_890 0.2 1e+2 2.1e3 2j 2.2j";
         let tokens = lex_source(source);

--- a/parser/src/lexer.rs
+++ b/parser/src/lexer.rs
@@ -1496,41 +1496,49 @@ mod tests {
                     value: "".to_string(),
                     kind: MagicKind::Magic,
                 },
+                #[cfg(feature = "full-lexer")]
                 Tok::NonLogicalNewline,
                 Tok::MagicCommand {
                     value: "".to_string(),
                     kind: MagicKind::Magic2,
                 },
+                #[cfg(feature = "full-lexer")]
                 Tok::NonLogicalNewline,
                 Tok::MagicCommand {
                     value: "".to_string(),
                     kind: MagicKind::Shell,
                 },
+                #[cfg(feature = "full-lexer")]
                 Tok::NonLogicalNewline,
                 Tok::MagicCommand {
                     value: "".to_string(),
                     kind: MagicKind::ShCap,
                 },
+                #[cfg(feature = "full-lexer")]
                 Tok::NonLogicalNewline,
                 Tok::MagicCommand {
                     value: "".to_string(),
                     kind: MagicKind::Help,
                 },
+                #[cfg(feature = "full-lexer")]
                 Tok::NonLogicalNewline,
                 Tok::MagicCommand {
                     value: "".to_string(),
                     kind: MagicKind::Help2,
                 },
+                #[cfg(feature = "full-lexer")]
                 Tok::NonLogicalNewline,
                 Tok::MagicCommand {
                     value: "".to_string(),
                     kind: MagicKind::Paren,
                 },
+                #[cfg(feature = "full-lexer")]
                 Tok::NonLogicalNewline,
                 Tok::MagicCommand {
                     value: "".to_string(),
                     kind: MagicKind::Quote,
                 },
+                #[cfg(feature = "full-lexer")]
                 Tok::NonLogicalNewline,
                 Tok::MagicCommand {
                     value: "".to_string(),
@@ -1566,51 +1574,61 @@ mod tests {
                     value: "foo".to_string(),
                     kind: MagicKind::Help,
                 },
+                #[cfg(feature = "full-lexer")]
                 Tok::NonLogicalNewline,
                 Tok::MagicCommand {
                     value: "foo".to_string(),
                     kind: MagicKind::Help2,
                 },
+                #[cfg(feature = "full-lexer")]
                 Tok::NonLogicalNewline,
                 Tok::MagicCommand {
                     value: "timeit a = b".to_string(),
                     kind: MagicKind::Magic,
                 },
+                #[cfg(feature = "full-lexer")]
                 Tok::NonLogicalNewline,
                 Tok::MagicCommand {
                     value: "timeit a % 3".to_string(),
                     kind: MagicKind::Magic,
                 },
+                #[cfg(feature = "full-lexer")]
                 Tok::NonLogicalNewline,
                 Tok::MagicCommand {
                     value: "matplotlib     --inline".to_string(),
                     kind: MagicKind::Magic,
                 },
+                #[cfg(feature = "full-lexer")]
                 Tok::NonLogicalNewline,
                 Tok::MagicCommand {
                     value: "pwd   && ls -a | sed 's/^/\\\\    /'".to_string(),
                     kind: MagicKind::Shell,
                 },
+                #[cfg(feature = "full-lexer")]
                 Tok::NonLogicalNewline,
                 Tok::MagicCommand {
                     value: "cd /Users/foo/Library/Application\\ Support/".to_string(),
                     kind: MagicKind::ShCap,
                 },
+                #[cfg(feature = "full-lexer")]
                 Tok::NonLogicalNewline,
                 Tok::MagicCommand {
                     value: "foo 1 2".to_string(),
                     kind: MagicKind::Paren,
                 },
+                #[cfg(feature = "full-lexer")]
                 Tok::NonLogicalNewline,
                 Tok::MagicCommand {
                     value: "foo 1 2".to_string(),
                     kind: MagicKind::Quote,
                 },
+                #[cfg(feature = "full-lexer")]
                 Tok::NonLogicalNewline,
                 Tok::MagicCommand {
                     value: "foo 1 2".to_string(),
                     kind: MagicKind::Quote2,
                 },
+                #[cfg(feature = "full-lexer")]
                 Tok::NonLogicalNewline,
                 Tok::MagicCommand {
                     value: "ls".to_string(),

--- a/parser/src/lexer.rs
+++ b/parser/src/lexer.rs
@@ -519,6 +519,7 @@ where
                     if matches!(self.window[1], Some('\n' | '\r')) {
                         self.next_char();
                         self.next_char();
+                        continue;
                     }
                 }
                 Some('\n' | '\r') | None => {
@@ -1486,6 +1487,33 @@ mod tests {
     #[test]
     fn test_jupyter_magic_line_continuation_windows_eol() {
         assert_jupyter_magic_line_continuation_with_eol(WINDOWS_EOL);
+    }
+
+    fn assert_jupyter_magic_line_continuation_with_eol_and_eof(eol: &str) {
+        let source = format!("%matplotlib \\{}", eol);
+        let tokens = lex_jupyter_source(&source);
+        assert_eq!(
+            tokens,
+            vec![Tok::MagicCommand {
+                value: "matplotlib ".to_string(),
+                kind: MagicKind::Magic
+            },]
+        )
+    }
+
+    #[test]
+    fn test_jupyter_magic_line_continuation_unix_eol_and_eof() {
+        assert_jupyter_magic_line_continuation_with_eol_and_eof(UNIX_EOL);
+    }
+
+    #[test]
+    fn test_jupyter_magic_line_continuation_mac_eol_and_eof() {
+        assert_jupyter_magic_line_continuation_with_eol_and_eof(MAC_EOL);
+    }
+
+    #[test]
+    fn test_jupyter_magic_line_continuation_windows_eol_and_eof() {
+        assert_jupyter_magic_line_continuation_with_eol_and_eof(WINDOWS_EOL);
     }
 
     #[test]

--- a/parser/src/parser.rs
+++ b/parser/src/parser.rs
@@ -1172,6 +1172,11 @@ def foo():
 
 # Transforms into `foo()`
 /foo
+
+# Indented magic
+for a in range(5):
+    %ls
+    pass
 "#
             .trim(),
             Mode::Jupyter,

--- a/parser/src/parser.rs
+++ b/parser/src/parser.rs
@@ -250,7 +250,7 @@ impl Parse for ast::Constant {
 }
 
 /// Parse a full Python program usually consisting of multiple lines.
-///  
+///
 /// This is a convenience function that can be used to parse a full Python program without having to
 /// specify the [`Mode`] or the location. It is probably what you want to use most of the time.
 ///
@@ -414,7 +414,12 @@ pub fn parse_tokens(
     #[cfg(feature = "full-lexer")]
     let lxr =
         lxr.filter_ok(|(tok, _)| !matches!(tok, Tok::Comment { .. } | Tok::NonLogicalNewline));
-    parse_filtered_tokens(lxr, mode, source_path)
+    if mode == Mode::Jupyter {
+        let lxr = lxr.filter_ok(|(tok, _)| !matches!(tok, Tok::MagicCommand(..)));
+        parse_filtered_tokens(lxr, mode, source_path)
+    } else {
+        parse_filtered_tokens(lxr, mode, source_path)
+    }
 }
 
 fn parse_filtered_tokens(

--- a/parser/src/parser.rs
+++ b/parser/src/parser.rs
@@ -433,7 +433,7 @@ pub fn parse_tokens(
     let lxr =
         lxr.filter_ok(|(tok, _)| !matches!(tok, Tok::Comment { .. } | Tok::NonLogicalNewline));
     if mode == Mode::Jupyter {
-        let lxr = lxr.filter_ok(|(tok, _)| !matches!(tok, Tok::MagicCommand(..)));
+        let lxr = lxr.filter_ok(|(tok, _)| !matches!(tok, Tok::MagicCommand { .. }));
         parse_filtered_tokens(lxr, mode, source_path)
     } else {
         parse_filtered_tokens(lxr, mode, source_path)
@@ -1170,8 +1170,10 @@ def foo():
         b
     )
 
-# Transforms into `foo()`
-/foo
+# Transforms into `foo(..)`
+/foo 1 2
+;foo 1 2
+,foo 1 2
 
 # Indented magic
 for a in range(5):

--- a/parser/src/parser.rs
+++ b/parser/src/parser.rs
@@ -1158,7 +1158,7 @@ class Abcd:
 !pwd && ls -a | sed 's/^/\    /'
 !pwd \
   && ls -a | sed 's/^/\\    /'
-!cd /Users/foo/Library/Application\ Support/
+!!cd /Users/foo/Library/Application\ Support/
 
 # Let's add some Python code to make sure that earlier escapes were handled
 # correctly and that we didn't consume any of the following code as a result

--- a/parser/src/parser.rs
+++ b/parser/src/parser.rs
@@ -1160,6 +1160,16 @@ class Abcd:
   && ls -a | sed 's/^/\\    /'
 !cd /Users/foo/Library/Application\ Support/
 
+# Let's add some Python code to make sure that earlier escapes were handled
+# correctly and that we didn't consume any of the following code as a result
+# of the escapes.
+def foo():
+    return (
+        a
+        !=
+        b
+    )
+
 # Transforms into `foo()`
 /foo
 "#

--- a/parser/src/snapshots/rustpython_parser__parser__tests__jupyter_magic.snap
+++ b/parser/src/snapshots/rustpython_parser__parser__tests__jupyter_magic.snap
@@ -4,7 +4,7 @@ expression: parse_ast
 ---
 Module(
     ModModule {
-        range: 0..735,
+        range: 0..736,
         body: [
             Expr(
                 StmtExpr {
@@ -33,13 +33,13 @@ Module(
             ),
             FunctionDef(
                 StmtFunctionDef {
-                    range: 565..625,
+                    range: 566..626,
                     name: Identifier {
                         id: "foo",
-                        range: 569..572,
+                        range: 570..573,
                     },
                     args: Arguments {
-                        range: 572..574,
+                        range: 573..575,
                         posonlyargs: [],
                         args: [],
                         vararg: None,
@@ -49,14 +49,14 @@ Module(
                     body: [
                         Return(
                             StmtReturn {
-                                range: 580..625,
+                                range: 581..626,
                                 value: Some(
                                     Compare(
                                         ExprCompare {
-                                            range: 597..619,
+                                            range: 598..620,
                                             left: Name(
                                                 ExprName {
-                                                    range: 597..598,
+                                                    range: 598..599,
                                                     id: "a",
                                                     ctx: Load,
                                                 },
@@ -67,7 +67,7 @@ Module(
                                             comparators: [
                                                 Name(
                                                     ExprName {
-                                                        range: 618..619,
+                                                        range: 619..620,
                                                         id: "b",
                                                         ctx: Load,
                                                     },
@@ -86,20 +86,20 @@ Module(
             ),
             For(
                 StmtFor {
-                    range: 700..735,
+                    range: 701..736,
                     target: Name(
                         ExprName {
-                            range: 704..705,
+                            range: 705..706,
                             id: "a",
                             ctx: Store,
                         },
                     ),
                     iter: Call(
                         ExprCall {
-                            range: 709..717,
+                            range: 710..718,
                             func: Name(
                                 ExprName {
-                                    range: 709..714,
+                                    range: 710..715,
                                     id: "range",
                                     ctx: Load,
                                 },
@@ -107,7 +107,7 @@ Module(
                             args: [
                                 Constant(
                                     ExprConstant {
-                                        range: 715..716,
+                                        range: 716..717,
                                         value: Int(
                                             5,
                                         ),
@@ -121,7 +121,7 @@ Module(
                     body: [
                         Pass(
                             StmtPass {
-                                range: 731..735,
+                                range: 732..736,
                             },
                         ),
                     ],

--- a/parser/src/snapshots/rustpython_parser__parser__tests__jupyter_magic.snap
+++ b/parser/src/snapshots/rustpython_parser__parser__tests__jupyter_magic.snap
@@ -4,7 +4,7 @@ expression: parse_ast
 ---
 Module(
     ModModule {
-        range: 0..657,
+        range: 0..711,
         body: [
             Expr(
                 StmtExpr {
@@ -81,6 +81,51 @@ Module(
                     ],
                     decorator_list: [],
                     returns: None,
+                    type_comment: None,
+                },
+            ),
+            For(
+                StmtFor {
+                    range: 676..711,
+                    target: Name(
+                        ExprName {
+                            range: 680..681,
+                            id: "a",
+                            ctx: Store,
+                        },
+                    ),
+                    iter: Call(
+                        ExprCall {
+                            range: 685..693,
+                            func: Name(
+                                ExprName {
+                                    range: 685..690,
+                                    id: "range",
+                                    ctx: Load,
+                                },
+                            ),
+                            args: [
+                                Constant(
+                                    ExprConstant {
+                                        range: 691..692,
+                                        value: Int(
+                                            5,
+                                        ),
+                                        kind: None,
+                                    },
+                                ),
+                            ],
+                            keywords: [],
+                        },
+                    ),
+                    body: [
+                        Pass(
+                            StmtPass {
+                                range: 707..711,
+                            },
+                        ),
+                    ],
+                    orelse: [],
                     type_comment: None,
                 },
             ),

--- a/parser/src/snapshots/rustpython_parser__parser__tests__jupyter_magic.snap
+++ b/parser/src/snapshots/rustpython_parser__parser__tests__jupyter_magic.snap
@@ -4,7 +4,7 @@ expression: parse_ast
 ---
 Module(
     ModModule {
-        range: 0..43,
+        range: 0..657,
         body: [
             Expr(
                 StmtExpr {
@@ -29,6 +29,59 @@ Module(
                             ),
                         },
                     ),
+                },
+            ),
+            FunctionDef(
+                StmtFunctionDef {
+                    range: 565..625,
+                    name: Identifier {
+                        id: "foo",
+                        range: 569..572,
+                    },
+                    args: Arguments {
+                        range: 572..574,
+                        posonlyargs: [],
+                        args: [],
+                        vararg: None,
+                        kwonlyargs: [],
+                        kwarg: None,
+                    },
+                    body: [
+                        Return(
+                            StmtReturn {
+                                range: 580..625,
+                                value: Some(
+                                    Compare(
+                                        ExprCompare {
+                                            range: 597..619,
+                                            left: Name(
+                                                ExprName {
+                                                    range: 597..598,
+                                                    id: "a",
+                                                    ctx: Load,
+                                                },
+                                            ),
+                                            ops: [
+                                                NotEq,
+                                            ],
+                                            comparators: [
+                                                Name(
+                                                    ExprName {
+                                                        range: 618..619,
+                                                        id: "b",
+                                                        ctx: Load,
+                                                    },
+                                                ),
+                                            ],
+                                        },
+                                    ),
+                                ),
+                            },
+                        ),
+                    ],
+                    decorator_list: [],
+                    returns: None,
+                    type_comment: None,
                 },
             ),
         ],

--- a/parser/src/snapshots/rustpython_parser__parser__tests__jupyter_magic.snap
+++ b/parser/src/snapshots/rustpython_parser__parser__tests__jupyter_magic.snap
@@ -4,7 +4,7 @@ expression: parse_ast
 ---
 Module(
     ModModule {
-        range: 0..711,
+        range: 0..735,
         body: [
             Expr(
                 StmtExpr {
@@ -86,20 +86,20 @@ Module(
             ),
             For(
                 StmtFor {
-                    range: 676..711,
+                    range: 700..735,
                     target: Name(
                         ExprName {
-                            range: 680..681,
+                            range: 704..705,
                             id: "a",
                             ctx: Store,
                         },
                     ),
                     iter: Call(
                         ExprCall {
-                            range: 685..693,
+                            range: 709..717,
                             func: Name(
                                 ExprName {
-                                    range: 685..690,
+                                    range: 709..714,
                                     id: "range",
                                     ctx: Load,
                                 },
@@ -107,7 +107,7 @@ Module(
                             args: [
                                 Constant(
                                     ExprConstant {
-                                        range: 691..692,
+                                        range: 715..716,
                                         value: Int(
                                             5,
                                         ),
@@ -121,7 +121,7 @@ Module(
                     body: [
                         Pass(
                             StmtPass {
-                                range: 707..711,
+                                range: 731..735,
                             },
                         ),
                     ],

--- a/parser/src/snapshots/rustpython_parser__parser__tests__jupyter_magic.snap
+++ b/parser/src/snapshots/rustpython_parser__parser__tests__jupyter_magic.snap
@@ -1,0 +1,37 @@
+---
+source: parser/src/parser.rs
+expression: parse_ast
+---
+Module(
+    ModModule {
+        range: 0..43,
+        body: [
+            Expr(
+                StmtExpr {
+                    range: 21..42,
+                    value: BinOp(
+                        ExprBinOp {
+                            range: 27..40,
+                            left: Name(
+                                ExprName {
+                                    range: 27..28,
+                                    id: "a",
+                                    ctx: Load,
+                                },
+                            ),
+                            op: Mod,
+                            right: Name(
+                                ExprName {
+                                    range: 39..40,
+                                    id: "b",
+                                    ctx: Load,
+                                },
+                            ),
+                        },
+                    ),
+                },
+            ),
+        ],
+        type_ignores: [],
+    },
+)

--- a/parser/src/token.rs
+++ b/parser/src/token.rs
@@ -51,7 +51,8 @@ pub enum Tok {
     /// the token stream prior to parsing.
     #[cfg(feature = "full-lexer")]
     NonLogicalNewline,
-    /// Jupyter magic commands which can start with `%`, `!` or `?`.
+    /// Token value for a Jupyter magic commands which can start with `%`, `!`, `?` or '/'. These
+    /// are filtered out of the token stream prior to parsing when the mode is [`Mode::Jupyter`].
     MagicCommand(String),
     /// Token value for an indent.
     Indent,

--- a/parser/src/token.rs
+++ b/parser/src/token.rs
@@ -203,10 +203,9 @@ pub enum Tok {
 impl Tok {
     pub fn start_marker(mode: Mode) -> Self {
         match mode {
-            Mode::Module => Tok::StartModule,
+            Mode::Module | Mode::Jupyter => Tok::StartModule,
             Mode::Interactive => Tok::StartInteractive,
             Mode::Expression => Tok::StartExpression,
-            Mode::Jupyter => Tok::StartModule,
         }
     }
 }

--- a/parser/src/token.rs
+++ b/parser/src/token.rs
@@ -51,6 +51,8 @@ pub enum Tok {
     /// the token stream prior to parsing.
     #[cfg(feature = "full-lexer")]
     NonLogicalNewline,
+    /// Jupyter magic commands which can start with `%`, `!` or `?`.
+    MagicCommand(String),
     /// Token value for an indent.
     Indent,
     /// Token value for a dedent.
@@ -204,6 +206,7 @@ impl Tok {
             Mode::Module => Tok::StartModule,
             Mode::Interactive => Tok::StartInteractive,
             Mode::Expression => Tok::StartExpression,
+            Mode::Jupyter => Tok::StartModule,
         }
     }
 }
@@ -227,6 +230,7 @@ impl fmt::Display for Tok {
             Newline => f.write_str("Newline"),
             #[cfg(feature = "full-lexer")]
             NonLogicalNewline => f.write_str("NonLogicalNewline"),
+            MagicCommand(value) => f.write_str(value),
             Indent => f.write_str("Indent"),
             Dedent => f.write_str("Dedent"),
             StartModule => f.write_str("StartProgram"),


### PR DESCRIPTION
Lex Jupyter line magic with `Mode::Jupyter`

This PR adds a new token `MagicCommand`[^1] which the lexer will recognize when in `Mode::Jupyter`. The rules for the lexer is as follows:
1. Given that we are at the start of line, skip the indentation and look for [characters that represent the start of a magic command](https://github.com/ipython/ipython/blob/635815e8f1ded5b764d66cacc80bbe25e9e2587f/IPython/core/inputtransformer2.py#L335-L346), determine the magic kind and capture all the characters following it as the command string.
2. If the command extends multiple lines, the lexer will skip the line continuation character (`\`) but only if it's followed by a newline (`\n` or `\r`). The reason to skip this only in case of newline is because they can occur in the command string which we should not skip:

	```rust
    //        Skip this backslash
    //        v
    //   !pwd \
    //      && ls -a | sed 's/^/\\    /'
    //                          ^^
    //                          Don't skip these backslashes
	```

3. The parser, when in `Mode::Jupyter`, will filter these tokens before the parsing begins. There is a small caveat when the magic command is indented. In the following example, when the parser filters out magic command, it'll throw an indentation error:

	```python
	for i in range(5):
		!ls

	# What the parser will see
	for i in range(5):
	
	```

[^1]: I would prefer to have some other name as this not only represent a line magic (`%`) but also shell command (`!`), help command (`?`) and others. In original implementation, it's named as ["IPython Syntax"](https://github.com/ipython/ipython/blob/635815e8f1ded5b764d66cacc80bbe25e9e2587f/IPython/core/inputtransformer2.py#L332)

