### PR TITLE
tuple constants are for optimisations, not source

### DIFF
--- a/ast/src/builtin.rs
+++ b/ast/src/builtin.rs
@@ -121,7 +121,6 @@ pub enum Constant {
     Str(String),
     Bytes(Vec<u8>),
     Int(BigInt),
-    Tuple(Vec<Constant>),
     Float(f64),
     Complex { real: f64, imag: f64 },
     Ellipsis,
@@ -178,20 +177,6 @@ impl std::fmt::Display for Constant {
                 f.pad(&repr)
             }
             Constant::Int(i) => i.fmt(f),
-            Constant::Tuple(tup) => {
-                if let [elt] = &**tup {
-                    write!(f, "({elt},)")
-                } else {
-                    f.write_str("(")?;
-                    for (i, elt) in tup.iter().enumerate() {
-                        if i != 0 {
-                            f.write_str(", ")?;
-                        }
-                        elt.fmt(f)?;
-                    }
-                    f.write_str(")")
-                }
-            }
             Constant::Float(fp) => f.pad(&rustpython_literal::float::to_string(*fp)),
             Constant::Complex { real, imag } => {
                 if *real == 0.0 {

--- a/ast/src/impls.rs
+++ b/ast/src/impls.rs
@@ -17,7 +17,6 @@ impl Expr {
                 | Constant::Float(_)
                 | Constant::Complex { .. }
                 | Constant::Bytes(_) => "literal",
-                Constant::Tuple(_) => "tuple",
                 Constant::Bool(b) => {
                     if *b {
                         "True"


### PR DESCRIPTION
my reading of https://docs.python.org/3/library/ast.html#ast.unparse and https://discuss.python.org/t/ast-constant-value-tuple-s-and-frozenset-s/22578 is that tuple constants cannot come from parsing python source, they are only for optimised bytecode

see also https://github.com/astral-sh/ruff/pull/5812