### PR TITLE
Fix empty lambda args range

### DIFF
--- a/parser/src/parser.rs
+++ b/parser/src/parser.rs
@@ -637,6 +637,13 @@ mod tests {
     }
 
     #[test]
+    fn test_parse_lambda_no_args() {
+        let source = "lambda: 1";
+        let parse_ast = ast::Suite::parse(source, "<test>").unwrap();
+        insta::assert_debug_snapshot!(parse_ast);
+    }
+
+    #[test]
     fn test_parse_tuples() {
         let source = "a, b = 4, 5";
 

--- a/parser/src/python.lalrpop
+++ b/parser/src/python.lalrpop
@@ -1245,10 +1245,10 @@ NamedExpression: ast::Expr = {
 };
 
 LambdaDef: ast::Expr = {
-    <location:@L> "lambda" <p:ParameterList<UntypedParameter, StarUntypedParameter, StarUntypedParameter>?> ":" <body:Test<"all">> <end_location:@R> =>? {
+    <location:@L> "lambda" <location_args:@L> <p:ParameterList<UntypedParameter, StarUntypedParameter, StarUntypedParameter>?> <end_location_args:@R> ":" <body:Test<"all">> <end_location:@R> =>? {
         p.as_ref().map(validate_arguments).transpose()?;
         let p = p
-            .unwrap_or_else(|| ast::Arguments::empty((location..end_location).into()));
+            .unwrap_or_else(|| ast::Arguments::empty((location_args..end_location_args).into()));
 
         Ok(ast::Expr::Lambda(
             ast::ExprLambda {

--- a/parser/src/python.rs
+++ b/parser/src/python.rs
@@ -1,5 +1,5 @@
 // auto-generated: "lalrpop 0.20.0"
-// sha3: 97fa7c01dee20861a5e5be31c0e0e1bccbc4396352b92ca6e5688d8f08b58cfe
+// sha3: e7613070cb5214ab021650015eb34d0a63631e3e1e61e1b26445cf55a4919727
 use crate::{
     ast::{self as ast, Ranged, bigint::BigInt},
     lexer::{LexicalError, LexicalErrorType},
@@ -32635,7 +32635,9 @@ fn __action178<
 >(
     (_, location, _): (TextSize, TextSize, TextSize),
     (_, _, _): (TextSize, token::Tok, TextSize),
+    (_, location_args, _): (TextSize, TextSize, TextSize),
     (_, p, _): (TextSize, core::option::Option<ast::Arguments>, TextSize),
+    (_, end_location_args, _): (TextSize, TextSize, TextSize),
     (_, _, _): (TextSize, token::Tok, TextSize),
     (_, body, _): (TextSize, ast::Expr, TextSize),
     (_, end_location, _): (TextSize, TextSize, TextSize),
@@ -32644,7 +32646,7 @@ fn __action178<
     {
         p.as_ref().map(validate_arguments).transpose()?;
         let p = p
-            .unwrap_or_else(|| ast::Arguments::empty((location..end_location).into()));
+            .unwrap_or_else(|| ast::Arguments::empty((location_args..end_location_args).into()));
 
         Ok(ast::Expr::Lambda(
             ast::ExprLambda {
@@ -43474,25 +43476,35 @@ fn __action820<
 >(
     __0: (TextSize, token::Tok, TextSize),
     __1: (TextSize, core::option::Option<ast::Arguments>, TextSize),
-    __2: (TextSize, token::Tok, TextSize),
-    __3: (TextSize, ast::Expr, TextSize),
-    __4: (TextSize, TextSize, TextSize),
+    __2: (TextSize, TextSize, TextSize),
+    __3: (TextSize, token::Tok, TextSize),
+    __4: (TextSize, ast::Expr, TextSize),
+    __5: (TextSize, TextSize, TextSize),
 ) -> Result<ast::Expr,__lalrpop_util::ParseError<TextSize,token::Tok,LexicalError>>
 {
     let __start0 = __0.0;
     let __end0 = __0.0;
+    let __start1 = __0.2;
+    let __end1 = __1.0;
     let __temp0 = __action387(
         &__start0,
         &__end0,
     );
     let __temp0 = (__start0, __temp0, __end0);
+    let __temp1 = __action387(
+        &__start1,
+        &__end1,
+    );
+    let __temp1 = (__start1, __temp1, __end1);
     __action178(
         __temp0,
         __0,
+        __temp1,
         __1,
         __2,
         __3,
         __4,
+        __5,
     )
 }
 
@@ -55169,19 +55181,27 @@ fn __action1303<
     __3: (TextSize, ast::Expr, TextSize),
 ) -> Result<ast::Expr,__lalrpop_util::ParseError<TextSize,token::Tok,LexicalError>>
 {
-    let __start0 = __3.2;
-    let __end0 = __3.2;
+    let __start0 = __1.2;
+    let __end0 = __2.0;
+    let __start1 = __3.2;
+    let __end1 = __3.2;
     let __temp0 = __action386(
         &__start0,
         &__end0,
     );
     let __temp0 = (__start0, __temp0, __end0);
+    let __temp1 = __action386(
+        &__start1,
+        &__end1,
+    );
+    let __temp1 = (__start1, __temp1, __end1);
     __action820(
         __0,
         __1,
+        __temp0,
         __2,
         __3,
-        __temp0,
+        __temp1,
     )
 }
 

--- a/parser/src/snapshots/rustpython_parser__function__tests__lambda_no_args.snap
+++ b/parser/src/snapshots/rustpython_parser__function__tests__lambda_no_args.snap
@@ -11,7 +11,7 @@ Ok(
                     ExprLambda {
                         range: 0..9,
                         args: Arguments {
-                            range: 0..9,
+                            range: 6..6,
                             posonlyargs: [],
                             args: [],
                             vararg: None,

--- a/parser/src/snapshots/rustpython_parser__parser__tests__parse_lambda_no_args.snap
+++ b/parser/src/snapshots/rustpython_parser__parser__tests__parse_lambda_no_args.snap
@@ -1,0 +1,33 @@
+---
+source: parser/src/parser.rs
+expression: parse_ast
+---
+[
+    Expr(
+        StmtExpr {
+            range: 0..9,
+            value: Lambda(
+                ExprLambda {
+                    range: 0..9,
+                    args: Arguments {
+                        range: 6..6,
+                        posonlyargs: [],
+                        args: [],
+                        vararg: None,
+                        kwonlyargs: [],
+                        kwarg: None,
+                    },
+                    body: Constant(
+                        ExprConstant {
+                            range: 8..9,
+                            value: Int(
+                                1,
+                            ),
+                            kind: None,
+                        },
+                    ),
+                },
+            ),
+        },
+    ),
+]


### PR DESCRIPTION
Previously, empty lambda arguments (e.g. `lambda: 1`) would get the range of the entire expression, which leads to incorrect comment placement. Now empty lambda arguments get an empty range between the `lambda` and the `:` tokens.