### PR TITLE
Fix BoolOp python.org link

### DIFF
--- a/ast/src/generic.rs
+++ b/ast/src/generic.rs
@@ -1820,7 +1820,7 @@ impl Node for ExprContext {
     const FIELD_NAMES: &'static [&'static str] = &[];
 }
 
-/// See also [boolop](https://docs.python.org/3/library/ast.html#ast.boolop)
+/// See also [boolop](https://docs.python.org/3/library/ast.html#ast.BoolOp)
 #[derive(Clone, Debug, PartialEq, is_macro::Is, Copy, Hash, Eq)]
 pub enum BoolOp {
     And,


### PR DESCRIPTION
Noticed https://docs.python.org/3/library/ast.html#ast.boolop wasn't working.