### PR TITLE
Remove parser ast re-export

### DIFF
--- a/ruff_python_parser/src/context.rs
+++ b/ruff_python_parser/src/context.rs
@@ -1,4 +1,4 @@
-use crate::ast::{self, Expr, ExprContext};
+use ruff_python_ast::{self as ast, Expr, ExprContext};
 
 pub(crate) fn set_context(expr: Expr, ctx: ExprContext) -> Expr {
     match expr {
@@ -49,7 +49,8 @@ pub(crate) fn set_context(expr: Expr, ctx: ExprContext) -> Expr {
 
 #[cfg(test)]
 mod tests {
-    use crate::{ast, Parse};
+    use crate::Parse;
+    use ruff_python_ast as ast;
 
     #[test]
     fn test_assign_name() {

--- a/ruff_python_parser/src/function.rs
+++ b/ruff_python_parser/src/function.rs
@@ -1,10 +1,7 @@
 // Contains functions that perform validation and parsing of arguments and parameters.
 // Checks apply both to functions and to lambdas.
-use crate::{
-    ast,
-    lexer::{LexicalError, LexicalErrorType},
-};
-use ruff_python_ast::Ranged;
+use crate::lexer::{LexicalError, LexicalErrorType};
+use ruff_python_ast::{self as ast, Ranged};
 use ruff_text_size::{TextRange, TextSize};
 use rustc_hash::FxHashSet;
 
@@ -138,7 +135,8 @@ const fn is_starred(exp: &ast::Expr) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{ast, parser::ParseErrorType, Parse};
+    use crate::{Parse, ParseErrorType};
+    use ruff_python_ast::{self as ast};
 
     macro_rules! function_and_lambda {
         ($($name:ident: $code:expr,)*) => {

--- a/ruff_python_parser/src/lib.rs
+++ b/ruff_python_parser/src/lib.rs
@@ -94,7 +94,8 @@
 //! mode or tokenizing the source beforehand:
 //!
 //! ```
-//! use ruff_python_parser::{Parse, ast};
+//! use ruff_python_parser::{Parse};
+//! use ruff_python_ast as ast;
 //!
 //! let python_source = r#"
 //! def is_odd(i):
@@ -112,7 +113,6 @@
 pub use parser::{parse, parse_starts_at, parse_tokens, Parse, ParseError, ParseErrorType};
 #[allow(deprecated)]
 pub use parser::{parse_expression, parse_expression_starts_at, parse_program};
-pub use ruff_python_ast as ast;
 pub use string::FStringErrorType;
 pub use token::{StringKind, Tok};
 

--- a/ruff_python_parser/src/parser.rs
+++ b/ruff_python_parser/src/parser.rs
@@ -20,12 +20,12 @@ use ruff_text_size::TextSize;
 
 use crate::lexer::{lex, lex_starts_at};
 use crate::{
-    ast::{self, Ranged},
     lexer::{self, LexResult, LexicalError, LexicalErrorType},
     python,
     token::Tok,
     Mode,
 };
+use ruff_python_ast::{self as ast, Ranged};
 
 /// Parse Python code string to implementor's type.
 ///
@@ -34,7 +34,8 @@ use crate::{
 /// For example, parsing a simple function definition and a call to that function:
 ///
 /// ```
-/// use ruff_python_parser::{self as parser, ast, Parse};
+/// use ruff_python_parser::{self as parser, Parse};
+/// use ruff_python_ast as ast;
 /// let source = r#"
 /// def foo():
 ///    return 42
@@ -50,7 +51,8 @@ use crate::{
 ///
 /// ```
 /// # use ruff_text_size::TextSize;
-/// # use ruff_python_parser::{self as parser, ast, Parse};
+/// # use ruff_python_ast as ast;
+/// # use ruff_python_parser::{self as parser, Parse};
 ///
 /// let expr = ast::Expr::parse_starts_at("1 + 2", "<embedded>", TextSize::from(400));
 /// assert!(expr.is_ok());
@@ -582,8 +584,9 @@ include!("gen/parse.rs");
 
 #[cfg(test)]
 mod tests {
-    use crate::{ast, Parse};
+    use crate::Parse;
     use insta::assert_debug_snapshot;
+    use ruff_python_ast as ast;
 
     use super::*;
 

--- a/ruff_python_parser/src/python.lalrpop
+++ b/ruff_python_parser/src/python.lalrpop
@@ -5,8 +5,8 @@
 
 use num_bigint::BigInt;
 use ruff_text_size::TextSize;
+use ruff_python_ast::{self as ast, Ranged, MagicKind};
 use crate::{
-    ast::{self as ast, Ranged, MagicKind},
     Mode,
     lexer::{LexicalError, LexicalErrorType},
     function::{ArgumentList, parse_args, validate_pos_params, validate_arguments},

--- a/ruff_python_parser/src/python.rs
+++ b/ruff_python_parser/src/python.rs
@@ -1,9 +1,9 @@
 // auto-generated: "lalrpop 0.20.0"
-// sha3: 44f1432ea449af8f70398fcbc3e641e2fd720734693a493e635795dd681954e0
+// sha3: bfe8038efa3e290b9841ea2f84a2278ded65476a00892aa448e9708655ccb86d
 use num_bigint::BigInt;
 use ruff_text_size::TextSize;
+use ruff_python_ast::{self as ast, Ranged, MagicKind};
 use crate::{
-    ast::{self as ast, Ranged, MagicKind},
     Mode,
     lexer::{LexicalError, LexicalErrorType},
     function::{ArgumentList, parse_args, validate_pos_params, validate_arguments},
@@ -24,8 +24,8 @@ mod __parse__Top {
 
     use num_bigint::BigInt;
     use ruff_text_size::TextSize;
+    use ruff_python_ast::{self as ast, Ranged, MagicKind};
     use crate::{
-    ast::{self as ast, Ranged, MagicKind},
     Mode,
     lexer::{LexicalError, LexicalErrorType},
     function::{ArgumentList, parse_args, validate_pos_params, validate_arguments},

--- a/ruff_python_parser/src/string.rs
+++ b/ruff_python_parser/src/string.rs
@@ -1,17 +1,19 @@
+use itertools::Itertools;
+
+use ruff_python_ast::{self as ast, Constant, Expr};
+use ruff_python_ast::{ConversionFlag, Ranged};
+use ruff_text_size::{TextLen, TextRange, TextSize};
+
 // Contains the logic for parsing string literals (mostly concerned with f-strings.)
 //
 // The lexer doesn't do any special handling of f-strings, it just treats them as
 // regular strings. Since the ruff_python_parser has no definition of f-string formats (Pending PEP 701)
 // we have to do the parsing here, manually.
 use crate::{
-    ast::{self, Constant, Expr},
     lexer::{LexicalError, LexicalErrorType},
     parser::{LalrpopError, Parse, ParseError, ParseErrorType},
     token::{StringKind, Tok},
 };
-use itertools::Itertools;
-use ruff_python_ast::{ConversionFlag, Ranged};
-use ruff_text_size::{TextLen, TextRange, TextSize};
 
 // unicode_name2 does not expose `MAX_NAME_LENGTH`, so we replicate that constant here, fix #3798
 const MAX_UNICODE_NAME: usize = 88;
@@ -831,8 +833,10 @@ impl From<FStringError> for LalrpopError<TextSize, Tok, LexicalError> {
 
 #[cfg(test)]
 mod tests {
+    use crate::Parse;
+    use ruff_python_ast as ast;
+
     use super::*;
-    use crate::{ast, Parse};
 
     fn parse_fstring(source: &str) -> Result<Vec<Expr>, LexicalError> {
         StringParser::new(source, StringKind::FString, false, TextSize::default()).parse()

--- a/ruff_python_parser/src/token.rs
+++ b/ruff_python_parser/src/token.rs
@@ -4,9 +4,9 @@
 //! loosely based on the token definitions found in the [CPython source].
 //!
 //! [CPython source]: https://github.com/python/cpython/blob/dfc2e065a2e71011017077e549cd2f9bf4944c54/Include/internal/pycore_token.h;
-use crate::ast::MagicKind;
 use crate::Mode;
 use num_bigint::BigInt;
+use ruff_python_ast::MagicKind;
 use ruff_text_size::TextSize;
 use std::fmt;
 


### PR DESCRIPTION
This PR removes the parser's AST re-export. Downstream dependency should directly import from the ast crate
